### PR TITLE
Add Date, Time, and DateTime types.

### DIFF
--- a/ISO_8601.md
+++ b/ISO_8601.md
@@ -102,4 +102,27 @@ Examples:
   - Extended: `YYYY-Www-DThh:mm±hh` ✅
 
   ## Time Interval
-  ...
+  1) A start and an end
+    - Basic: `YYYYMMDDThhmmss/YYYYMMDDThhmmss`
+    - Extended: `YYYY-MM-DDThh:mm:ss/YYYY-MM-DDThh:mm:ss`
+  2) A duration and context info (only duration provided by ISO str)
+    - Basic/Extended: 
+      - `PnnYnnMnnDTnnHnnMnnS`
+      - `PnnW`
+    - Alternate:
+      - Basic: `PYYYYMMDDThhmmss`
+      - Extended: `PYYYY-MM-DDThh:mm:ss`
+  3) A start and a duration
+    - Basic: 
+      - `YYYYMMDDThhmmss/PnnYnnMnnDTnnHnnMnnS`
+      - `YYYYMMDDThhmmss/PYYYYMMDDThhmmss`
+    - Extended:
+      - `YYYY-MM-DDThh:mm:ss/PnnYnnMnnDTnnHnnMnnS`
+      - `YYYY-MM-DDThh:mm:ss/PYYYY-MM-DDThh:mm:ss`
+  4) A duration and an end
+    - Basic:
+      - `PnnYnnMnnDTnnHnnMnnS/YYYYMMDDThhmmss`
+      - `PYYYYMMDDThhmmss/YYYYMMDDThhmmss`
+    - Extended:
+      - `PnnYnnMnnDTnnHnnMnnS/YYYY-MM-DDThh:mm:ss`
+      - `PYYYY-MM-DDThh:mm:ss/YYYY-MM-DDThh:mm:ss`

--- a/ci/all_tests.sh
+++ b/ci/all_tests.sh
@@ -13,4 +13,4 @@ for roc_file in $package_dir*.roc; do
 done
 
 $roc test ./package/Tests.roc
-$roc test ./package/Utc.roc
+$roc test ./package/main.roc

--- a/package/Date.roc
+++ b/package/Date.roc
@@ -66,6 +66,14 @@ fromUtcHelper =\days, year ->
         else
             { year: year, dayOfYear: days + 1 |> Num.toU16 }
 
+toUtc : Date -> Utc.Utc
+toUtc =\date ->
+    days = numDaysSinceEpoch {year: date.year |> Num.toU64, month: 1, day: 1} + (date.dayOfYear - 1 |> Num.toI64)
+    Utc.fromNanosSinceEpoch (days |> Num.toI128 |> Num.mul (Const.nanosPerHour * 24))
+
+
+# <==== TESTS ====>
+# <---- fromUtc ---->
 expect
     utc = Utc.fromNanosSinceEpoch 0
     fromUtc utc == { year: 1970, dayOfYear: 1 }
@@ -94,11 +102,7 @@ expect
     utc = Utc.fromNanosSinceEpoch -1
     fromUtc utc == { year: 1969, dayOfYear: 365 }
 
-toUtc : Date -> Utc.Utc
-toUtc =\date ->
-    days = numDaysSinceEpoch {year: date.year |> Num.toU64, month: 1, day: 1} + (date.dayOfYear - 1 |> Num.toI64)
-    Utc.fromNanosSinceEpoch (days |> Num.toI128 |> Num.mul (Const.nanosPerHour * 24))
-
+# <---- toUtc ---->
 expect 
     utc = toUtc { year: 1970, dayOfYear: 1 } 
     utc == Utc.fromNanosSinceEpoch 0

--- a/package/Date.roc
+++ b/package/Date.roc
@@ -7,6 +7,7 @@ interface Date
         unixEpoch,
     ]
     imports [
+        Utc,
         Utils.{
             isLeapYear,
             ymdToDaysInYear,
@@ -43,5 +44,10 @@ fromYw = \year, week ->
     fromYwd year week 1
 
 expect fromYw 1970 1 == { year: 1970, dayOfYear: 1 }
+
+fromUtc : Utc -> Date
+
+toUtc : Date -> Utc
+        
 
 

--- a/package/Date.roc
+++ b/package/Date.roc
@@ -1,0 +1,47 @@
+interface Date
+    exposes [
+        Date,
+        fromYmd,
+        fromYw,
+        fromYwd,
+        unixEpoch,
+    ]
+    imports [
+        Utils.{
+            isLeapYear,
+            ymdToDaysInYear,
+            calendarWeekToDaysInYear,
+        }
+    ]
+
+Date : { year: I64, dayOfYear: U16 }
+
+unixEpoch : Date
+unixEpoch = { year: 1970, dayOfYear: 1 }
+
+fromYmd : Int *, Int *, Int * -> Date
+fromYmd =\year, month, day -> 
+    { year: Num.toI64 year, dayOfYear: ymdToDaysInYear year month day }
+
+expect 
+    fromYmd 1970 1 1 == { year: 1970, dayOfYear: 1 }
+
+fromYwd : Int *, Int *, Int * -> Date
+fromYwd = \year, week, day ->
+    daysInYear = if isLeapYear year then 366 else 365
+    d = calendarWeekToDaysInYear week year |> Num.add (Num.toU64 day)
+    if d > daysInYear then
+        { year: Num.toI64 (year + 1), dayOfYear: Num.toU16 (d - daysInYear) }
+    else
+        { year: Num.toI64 year, dayOfYear: Num.toU16 d }
+
+expect fromYwd 1970 1 1 == { year: 1970, dayOfYear: 1 }
+expect fromYwd 1970 52 5 == { year: 1971, dayOfYear: 1 }
+
+fromYw : Int *, Int * -> Date
+fromYw = \year, week ->
+    fromYwd year week 1
+
+expect fromYw 1970 1 == { year: 1970, dayOfYear: 1 }
+
+

--- a/package/Date.roc
+++ b/package/Date.roc
@@ -2,6 +2,7 @@ interface Date
     exposes [
         Date,
         fromUtc,
+        fromYd,
         fromYmd,
         fromYw,
         fromYwd,
@@ -24,12 +25,12 @@ Date : { year: I64, dayOfYear: U16 }
 unixEpoch : Date
 unixEpoch = { year: 1970, dayOfYear: 1 }
 
+fromYd : Int *, Int * -> Date
+fromYd = \year, dayOfYear -> { year: Num.toI64 year, dayOfYear: Num.toU16 dayOfYear }
+
 fromYmd : Int *, Int *, Int * -> Date
 fromYmd =\year, month, day -> 
     { year: Num.toI64 year, dayOfYear: ymdToDaysInYear year month day }
-
-expect 
-    fromYmd 1970 1 1 == { year: 1970, dayOfYear: 1 }
 
 fromYwd : Int *, Int *, Int * -> Date
 fromYwd = \year, week, day ->
@@ -40,14 +41,9 @@ fromYwd = \year, week, day ->
     else
         { year: Num.toI64 year, dayOfYear: Num.toU16 d }
 
-expect fromYwd 1970 1 1 == { year: 1970, dayOfYear: 1 }
-expect fromYwd 1970 52 5 == { year: 1971, dayOfYear: 1 }
-
 fromYw : Int *, Int * -> Date
 fromYw = \year, week ->
     fromYwd year week 1
-
-expect fromYw 1970 1 == { year: 1970, dayOfYear: 1 }
 
 fromUtc : Utc.Utc -> Date
 fromUtc =\utc ->
@@ -73,6 +69,19 @@ toUtc =\date ->
 
 
 # <==== TESTS ====>
+# <---- fromYmd ---->
+expect fromYmd 1970 1 1 == { year: 1970, dayOfYear: 1 }
+expect fromYmd 1970 12 31 == { year: 1970, dayOfYear: 365 }
+expect fromYmd 1972 3 1 == { year: 1972, dayOfYear: 61 }
+
+# <---- fromYwd ---->
+expect fromYwd 1970 1 1 == { year: 1970, dayOfYear: 1 }
+expect fromYwd 1970 52 5 == { year: 1971, dayOfYear: 1 }
+
+# <---- fromYw ---->
+expect fromYw 1970 1 == { year: 1970, dayOfYear: 1 }
+expect fromYw 1971 1 == { year: 1971, dayOfYear: 4 }
+
 # <---- fromUtc ---->
 expect
     utc = Utc.fromNanosSinceEpoch 0

--- a/package/Date.roc
+++ b/package/Date.roc
@@ -5,6 +5,7 @@ interface Date
         fromYmd,
         fromYw,
         fromYwd,
+        toUtc,
         unixEpoch,
     ]
     imports [
@@ -12,6 +13,7 @@ interface Date
         Utc,
         Utils.{
             isLeapYear,
+            numDaysSinceEpoch,
             ymdToDaysInYear,
             calendarWeekToDaysInYear,
         }
@@ -93,4 +95,30 @@ expect
     fromUtc utc == { year: 1969, dayOfYear: 365 }
 
 toUtc : Date -> Utc.Utc
+toUtc =\date ->
+    days = numDaysSinceEpoch {year: date.year |> Num.toU64, month: 1, day: 1} + (date.dayOfYear - 1 |> Num.toI64)
+    Utc.fromNanosSinceEpoch (days |> Num.toI128 |> Num.mul (Const.nanosPerHour * 24))
 
+expect 
+    utc = toUtc { year: 1970, dayOfYear: 1 } 
+    utc == Utc.fromNanosSinceEpoch 0
+
+expect 
+    utc = toUtc { year: 1970, dayOfYear: 365 }
+    utc == Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * 364)
+
+expect
+    utc = toUtc { year: 1973, dayOfYear: 1 }
+    utc == Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * 365 * 2 + Const.nanosPerHour * 24 * 366)
+
+expect
+    utc = toUtc { year: 1969, dayOfYear: 365 }
+    utc == Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * -1)
+
+expect
+    utc = toUtc { year: 1969, dayOfYear: 1 }
+    utc == Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * -365)
+
+expect
+    utc = toUtc { year: 1968, dayOfYear: 1 }
+    utc == Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * -365 - Const.nanosPerHour * 24 * 366)

--- a/package/DateTime.roc
+++ b/package/DateTime.roc
@@ -1,0 +1,56 @@
+interface DateTime
+    exposes [
+        fromYmd,
+        fromYw,
+        fromYwd,
+    ]
+    imports [
+        Date,
+        Time,
+    ]
+
+DateTime : { date: Date.Date, time: Time.Time }
+
+fromYmd : Int *, Int *, Int * -> DateTime
+fromYmd =\year, month, day -> 
+    { date: Date.fromYmd year month day, time: Time.midnight }
+
+expect 
+    dateTime = fromYmd 1970 1 1
+    dateTime.date.year == 1970 &&
+    dateTime.date.dayOfYear == 1 &&
+    dateTime.time == Time.midnight
+
+expect 
+    dateTime = fromYmd 1970 12 31
+    dateTime.date.year == 1970 &&
+    dateTime.date.dayOfYear == 365 &&
+    dateTime.time == Time.midnight
+
+fromYwd : Int *, Int *, Int * -> DateTime
+fromYwd = \year, week, day ->
+    { date: Date.fromYwd year week day, time: Time.midnight }
+
+expect 
+    dateTime = fromYwd 1970 1 1
+    dateTime.date.year == 1970 &&
+    dateTime.date.dayOfYear == 1 &&
+    dateTime.time == Time.midnight
+
+expect
+    dateTime = fromYwd 1970 52 4
+    dateTime.date.year == 1970 &&
+    dateTime.date.dayOfYear == 365 &&
+    dateTime.time == Time.midnight
+
+fromYw : Int *, Int * -> DateTime
+fromYw = \year, week ->
+    { date: Date.fromYw year week, time: Time.midnight }
+
+expect 
+    dateTime = fromYw 1970 1 
+    dateTime.date.year == 1970 &&
+    dateTime.date.dayOfYear == 1 &&
+    dateTime.time == Time.midnight
+
+

--- a/package/DateTime.roc
+++ b/package/DateTime.roc
@@ -1,56 +1,73 @@
 interface DateTime
     exposes [
+        fromUtc,
+        fromYd,
         fromYmd,
         fromYw,
         fromYwd,
+        fromYmdhms,
+        fromYmdhmsn,
+        toUtc,
+        unixEpoch,
     ]
     imports [
+        Const,
         Date,
         Time,
+        Utc,
+        Utc.{ Utc },
+        UtcTime,
     ]
 
-DateTime : { date: Date.Date, time: Time.Time }
+DateTime : { date : Date.Date, time : Time.Time }
+
+unixEpoch : DateTime
+unixEpoch = { date: Date.unixEpoch, time: Time.midnight }
+
+fromYd : Int *, Int * -> DateTime
+fromYd = \year, day -> { date: Date.fromYd year day, time: Time.midnight }
 
 fromYmd : Int *, Int *, Int * -> DateTime
-fromYmd =\year, month, day -> 
-    { date: Date.fromYmd year month day, time: Time.midnight }
-
-expect 
-    dateTime = fromYmd 1970 1 1
-    dateTime.date.year == 1970 &&
-    dateTime.date.dayOfYear == 1 &&
-    dateTime.time == Time.midnight
-
-expect 
-    dateTime = fromYmd 1970 12 31
-    dateTime.date.year == 1970 &&
-    dateTime.date.dayOfYear == 365 &&
-    dateTime.time == Time.midnight
+fromYmd = \year, month, day -> { date: Date.fromYmd year month day, time: Time.midnight }
 
 fromYwd : Int *, Int *, Int * -> DateTime
-fromYwd = \year, week, day ->
-    { date: Date.fromYwd year week day, time: Time.midnight }
-
-expect 
-    dateTime = fromYwd 1970 1 1
-    dateTime.date.year == 1970 &&
-    dateTime.date.dayOfYear == 1 &&
-    dateTime.time == Time.midnight
-
-expect
-    dateTime = fromYwd 1970 52 4
-    dateTime.date.year == 1970 &&
-    dateTime.date.dayOfYear == 365 &&
-    dateTime.time == Time.midnight
+fromYwd = \year, week, day -> { date: Date.fromYwd year week day, time: Time.midnight }
 
 fromYw : Int *, Int * -> DateTime
-fromYw = \year, week ->
-    { date: Date.fromYw year week, time: Time.midnight }
+fromYw = \year, week -> { date: Date.fromYw year week, time: Time.midnight }
 
-expect 
-    dateTime = fromYw 1970 1 
-    dateTime.date.year == 1970 &&
-    dateTime.date.dayOfYear == 1 &&
-    dateTime.time == Time.midnight
+fromYmdhms : Int *, Int *, Int *, Int *, Int *, Int * -> DateTime
+fromYmdhms = \year, month, day, hour, minute, second ->
+    { date: Date.fromYmd year month day, time: Time.fromHms hour minute second }
 
+fromYmdhmsn : Int *, Int *, Int *, Int *, Int *, Int *, Int * -> DateTime
+fromYmdhmsn = \year, month, day, hour, minute, second, nanosecond ->
+    { date: Date.fromYmd year month day, time: Time.fromHmsn hour minute second nanosecond }
 
+toUtc : DateTime -> Utc
+toUtc =\ dateTime ->
+    dateNanos = Date.toUtc dateTime.date |> Utc.toNanosSinceEpoch
+    timeNanos = Time.toUtcTime dateTime.time |> UtcTime.toNanosSinceMidnight |> Num.toI128
+    Utc.fromNanosSinceEpoch (dateNanos + timeNanos)
+
+expect
+    utc = toUtc (fromYmdhmsn 1970 12 31 12 34 56 5)
+    utc == Utc.fromNanosSinceEpoch (364 * 24 * 60 * 60 * 1_000_000_000 + 12 * 60 * 60 * 1_000_000_000 + 34 * 60 * 1_000_000_000 + 56 * 1_000_000_000 + 5)
+
+fromUtc : Utc -> DateTime
+fromUtc = \utc ->
+    nanos = Utc.toNanosSinceEpoch utc
+    timeNanos = if nanos < 0 && nanos % (Const.nanosPerHour * 24) != 0 then
+        nanos % (Const.nanosPerHour * 24) + Const.nanosPerHour * 24 else nanos % (Const.nanosPerHour * 24)
+    dateNanos = nanos - timeNanos |> Num.toI128
+    date = dateNanos |> Num.toI128 |> Utc.fromNanosSinceEpoch |> Date.fromUtc
+    time = timeNanos |> Num.toI64 |> UtcTime.fromNanosSinceMidnight |> Time.fromUtcTime
+    { date, time }    
+
+expect
+    dateTime = fromUtc (Utc.fromNanosSinceEpoch (364 * 24 * Const.nanosPerHour + 12 * Const.nanosPerHour + 34 * Const.nanosPerMinute + 56 * Const.nanosPerSecond + 5))
+    dateTime == fromYmdhmsn 1970 12 31 12 34 56 5
+
+expect
+    dateTime = fromUtc (Utc.fromNanosSinceEpoch (-1))
+    dateTime == fromYmdhmsn 1969 12 31 23 59 59 (Const.nanosPerSecond - 1)

--- a/package/DateTimes/ABOUT.MD
+++ b/package/DateTimes/ABOUT.MD
@@ -1,0 +1,1 @@
+hasnept/roc-datetimes

--- a/package/DateTimes/Conversion.roc
+++ b/package/DateTimes/Conversion.roc
@@ -1,4 +1,4 @@
-interface Conversion
+interface DateTimes.Conversion
     exposes [
         daysInAWeek,
         daysToSeconds,

--- a/package/DateTimes/Conversion.roc
+++ b/package/DateTimes/Conversion.roc
@@ -1,0 +1,98 @@
+interface Conversion
+    exposes [
+        daysInAWeek,
+        daysToSeconds,
+        hoursInADay,
+        hoursToSeconds,
+        microsecondsInAMillisecond,
+        microsecondsInASecond,
+        microsecondsToNanoseconds,
+        microsecondsToWholeMilliseconds,
+        microsecondsToWholeSeconds,
+        millisecondsInASecond,
+        millisecondsToMicroseconds,
+        millisecondsToNanoseconds,
+        millisecondsToWholeSeconds,
+        minutesInAnHour,
+        minutesToSeconds,
+        nanosecondsInAMicrosecond,
+        nanosecondsInAMillisecond,
+        nanosecondsInASecond,
+        nanosecondsToWholeMilliseconds,
+        nanosecondsToWholeSeconds,
+        nanosecondsToWholeMicroseconds,
+        secondsInAMinute,
+        secondsInAWeek,
+        secondsInADay,
+        secondsInAnHour,
+        secondsToMicroseconds,
+        secondsToMilliseconds,
+        secondsToNanoseconds,
+        secondsToWholeDays,
+        secondsToWholeHours,
+        secondsToWholeMinutes,
+        secondsToWholeWeeks,
+        weeksToSeconds,
+    ]
+    imports []
+
+# Constants
+
+nanosecondsInAMicrosecond = 1_000
+microsecondsInAMillisecond = 1_000
+millisecondsInASecond = 1_000
+secondsInAMinute = 60
+minutesInAnHour = 60
+hoursInADay = 24
+daysInAWeek = 7
+
+microsecondsInASecond = microsecondsInAMillisecond * millisecondsInASecond
+nanosecondsInAMillisecond = nanosecondsInAMicrosecond * microsecondsInAMillisecond
+nanosecondsInASecond = nanosecondsInAMicrosecond * microsecondsInASecond
+secondsInADay = secondsInAMinute * minutesInAnHour * hoursInADay
+secondsInAnHour = secondsInAMinute * minutesInAnHour
+secondsInAWeek = secondsInAMinute * minutesInAnHour * hoursInADay * daysInAWeek
+
+# Nanoseconds
+
+nanosecondsToWholeMilliseconds = \nanoseconds -> nanoseconds // nanosecondsInAMillisecond
+nanosecondsToWholeSeconds = \nanoseconds -> nanoseconds // nanosecondsInASecond
+nanosecondsToWholeMicroseconds = \nanoseconds -> nanoseconds // nanosecondsInAMicrosecond
+
+# Microseconds
+
+microsecondsToNanoseconds = \microseconds -> microseconds * nanosecondsInAMicrosecond
+microsecondsToWholeMilliseconds = \microseconds -> microseconds // microsecondsInAMillisecond
+microsecondsToWholeSeconds = \microseconds -> microseconds // microsecondsInASecond
+
+# Milliseconds
+
+millisecondsToMicroseconds = \milliseconds -> milliseconds * microsecondsInAMillisecond
+millisecondsToNanoseconds = \milliseconds -> milliseconds * nanosecondsInAMillisecond
+millisecondsToWholeSeconds = \milliseconds -> milliseconds // millisecondsInASecond
+
+# Seconds
+
+secondsToMicroseconds = \seconds -> seconds * microsecondsInASecond
+secondsToMilliseconds = \seconds -> seconds * millisecondsInASecond
+secondsToNanoseconds = \seconds -> seconds * nanosecondsInASecond
+secondsToWholeDays = \seconds -> seconds // secondsInADay
+secondsToWholeHours = \seconds -> seconds // secondsInAnHour
+secondsToWholeMinutes = \seconds -> seconds // secondsInAMinute
+secondsToWholeWeeks = \seconds -> seconds // secondsInAWeek
+
+# Minutes
+
+minutesToSeconds = \minutes -> minutes * secondsInAMinute
+
+# Hours
+
+hoursToSeconds = \hours -> hours * secondsInAnHour
+
+# Days
+
+daysToSeconds = \days -> days * secondsInADay
+
+# Weeks
+
+weeksToSeconds = \weeks -> (Num.toI64 weeks) * secondsInAWeek

--- a/package/DateTimes/Duration.roc
+++ b/package/DateTimes/Duration.roc
@@ -1,0 +1,532 @@
+interface Duration
+    exposes [
+        add,
+        Duration,
+        fromDays,
+        fromHours,
+        fromMicroseconds,
+        fromMilliseconds,
+        fromMinutes,
+        fromNanoseconds,
+        fromSeconds,
+        fromWeeks,
+        max,
+        min,
+        toNanoseconds,
+        toWholeDays,
+        toWholeHours,
+        toWholeMinutes,
+        toWholeSeconds,
+        toWholeWeeks,
+        zero,
+    ]
+    imports [
+        Utils,
+        Conversion,
+    ]
+
+## An amount of time measured to the nanosecond.
+##
+## The maximum value of this type is Num.maxI64 seconds + 999_999_999 nanoseconds, approximately 292 billion years.
+## The minimum value of this type is Num.minI64 seconds, approximately -292 billion years.
+Duration : { seconds : I64, nanoseconds : U32 }
+
+# Constructors
+
+## Zero duration.
+zero = { seconds: 0, nanoseconds: 0 }
+
+## The maximum possible duration, approximately 292 billion years
+max : Duration
+max = { seconds: Num.maxI64, nanoseconds: 999_999_999 }
+
+## The minimum possible duration, approximately -292 billion years.
+min : Duration
+min = { seconds: Num.minI64, nanoseconds: 0 }
+
+## Convert a number of nanoseconds to a duration.
+fromNanoseconds : I64 -> Duration
+fromNanoseconds = \nanoseconds ->
+    (seconds, nanosecondsRemainder) = Utils.flooredIntegerDivisionAndModulus nanoseconds Conversion.nanosecondsInASecond
+    if Num.isNegative nanosecondsRemainder then
+        {
+            seconds: (seconds - 1),
+            nanoseconds: Num.toU32 (Conversion.nanosecondsInASecond + nanosecondsRemainder),
+        }
+    else
+        {
+            seconds: seconds,
+            nanoseconds: Num.toU32 nanosecondsRemainder,
+        }
+
+expect
+    out = fromNanoseconds 123
+    out == { seconds: 0, nanoseconds: 123 }
+
+expect
+    out = fromNanoseconds -123
+    out == { seconds: -1, nanoseconds: 999_999_877 }
+
+expect
+    out = fromNanoseconds Num.maxI64
+    out == { seconds: 9_223_372_036, nanoseconds: 854_775_807 }
+
+expect
+    out = fromNanoseconds Num.minI64
+    out == { seconds: -9_223_372_037, nanoseconds: 145_224_192 }
+
+## Convert a number of milliseconds to a duration.
+fromMilliseconds : I64 -> Duration
+fromMilliseconds = \milliseconds ->
+    (seconds, millisecondsRemainder) = Utils.flooredIntegerDivisionAndModulus milliseconds Conversion.nanosecondsInAMillisecond
+    if Num.isNegative millisecondsRemainder then
+        {
+            seconds: (seconds - 1),
+            nanoseconds: Num.toU32 (Conversion.nanosecondsInASecond + (Conversion.millisecondsToNanoseconds millisecondsRemainder)),
+        }
+    else
+        {
+            seconds: seconds,
+            nanoseconds: Num.toU32 (Conversion.millisecondsToNanoseconds millisecondsRemainder),
+        }
+
+expect
+    out = fromMilliseconds 123
+    out == { seconds: 0, nanoseconds: 123_000_000 }
+
+expect
+    out = fromMilliseconds -123
+    out == { seconds: -1, nanoseconds: 877_000_000 }
+
+expect
+    out = fromMilliseconds Num.maxI64
+    out == { seconds: 9_223_372_036_854, nanoseconds: 2_712_886_720 }
+
+expect
+    out = fromMilliseconds Num.minI64
+    out == { seconds: -9_223_372_036_855, nanoseconds: 2_581_080_576 }
+
+## Convert a number of microseconds to a duration.
+fromMicroseconds : I64 -> Duration
+fromMicroseconds = \microseconds ->
+    (seconds, microsecondsRemainder) = Utils.flooredIntegerDivisionAndModulus microseconds Conversion.microsecondsInASecond
+    if Num.isNegative microsecondsRemainder then
+        {
+            seconds: (seconds - 1),
+            nanoseconds: Num.toU32 (Conversion.nanosecondsInASecond + (Conversion.microsecondsToNanoseconds microsecondsRemainder)),
+        }
+    else
+        {
+            seconds: seconds,
+            nanoseconds: Num.toU32 (Conversion.microsecondsToNanoseconds microsecondsRemainder),
+        }
+
+expect
+    out = fromMicroseconds 123
+    out == { seconds: 0, nanoseconds: 123_000 }
+
+expect
+    out = fromMicroseconds -123
+    out == { seconds: -1, nanoseconds: 999_877_000 }
+
+expect
+    out = fromMicroseconds Num.maxI64
+    out == { seconds: 9_223_372_036_854, nanoseconds: 775_807_000 }
+
+expect
+    out = fromMicroseconds Num.minI64
+    out == { seconds: -9_223_372_036_855, nanoseconds: 224_192_000 }
+
+## Convert a number of seconds to a duration.
+fromSeconds : I64 -> Duration
+fromSeconds = \seconds -> { seconds, nanoseconds: 0 }
+
+expect
+    out = fromSeconds 123
+    out == { seconds: 123, nanoseconds: 0 }
+
+expect
+    out = fromSeconds Num.maxI64
+    out == { seconds: Num.maxI64, nanoseconds: 0 }
+
+expect
+    out = fromSeconds Num.minI64
+    out == { seconds: Num.minI64, nanoseconds: 0 }
+
+## Convert a number of minutes to a duration.
+fromMinutes : I32 -> Duration
+fromMinutes = \minutes -> { seconds: Conversion.minutesToSeconds (Num.toI64 minutes), nanoseconds: 0 }
+
+expect
+    out = fromMinutes 123
+    out == { seconds: 7380, nanoseconds: 0 }
+
+expect
+    out = fromMinutes Num.maxI32
+    out == { seconds: 128_849_018_820, nanoseconds: 0 }
+
+expect
+    out = fromMinutes Num.minI32
+    out == { seconds: -128_849_018_880, nanoseconds: 0 }
+
+## Convert a number of hours to a duration.
+fromHours : I32 -> Duration
+fromHours = \hours -> { seconds: Conversion.hoursToSeconds (Num.toI64 hours), nanoseconds: 0 }
+
+expect
+    out = fromHours 123
+    out == { seconds: 442_800, nanoseconds: 0 }
+
+expect
+    out = fromHours Num.maxI32
+    out == { seconds: 7_730_941_129_200, nanoseconds: 0 }
+
+expect
+    out = fromHours Num.minI32
+    out == { seconds: -7_730_941_132_800, nanoseconds: 0 }
+
+## Convert a number of days to a duration.
+fromDays : I32 -> Duration
+fromDays = \days -> { seconds: Conversion.daysToSeconds (Num.toI64 days), nanoseconds: 0 }
+
+expect
+    out = fromDays 123
+    out == { seconds: 10_627_200, nanoseconds: 0 }
+
+expect
+    out = fromDays Num.maxI32
+    out == { seconds: 185_542_587_100_800, nanoseconds: 0 }
+
+expect
+    out = fromDays Num.minI32
+    out == { seconds: -185_542_587_187_200, nanoseconds: 0 }
+
+## Convert a number of weeks to a duration.
+fromWeeks : I32 -> Duration
+fromWeeks = \weeks -> { seconds: Conversion.weeksToSeconds (Num.toI64 weeks), nanoseconds: 0 }
+
+expect
+    out = fromWeeks 123
+    out == { seconds: 74_390_400, nanoseconds: 0 }
+
+expect
+    out = fromWeeks Num.maxI32
+    out == { seconds: 1_298_798_109_705_600, nanoseconds: 0 }
+
+expect
+    out = fromWeeks Num.minI32
+    out == { seconds: -1_298_798_110_310_400, nanoseconds: 0 }
+
+# Methods
+
+## Get the number of nanoseconds in the duration.
+toNanoseconds : Duration -> I128
+toNanoseconds = \duration -> Conversion.secondsToNanoseconds (Num.toI128 duration.seconds) + Num.toI128 duration.nanoseconds
+
+expect
+    out = toNanoseconds zero
+    out == 0
+
+expect
+    halfASecond = { seconds: 0, nanoseconds: 500_000_000 }
+    out = toNanoseconds halfASecond
+    out == 500_000_000
+
+expect
+    oneSecond = { seconds: 1, nanoseconds: 0 }
+    out = toNanoseconds oneSecond
+    out == 1_000_000_000
+
+expect
+    negativeOneSecond = { seconds: -1, nanoseconds: 0 }
+    out = toNanoseconds negativeOneSecond
+    out == -1_000_000_000
+
+expect
+    oneAndAHalfSeconds = { seconds: 1, nanoseconds: 500_000_000 }
+    out = toNanoseconds oneAndAHalfSeconds
+    out == 1_500_000_000
+
+expect
+    negativeHalfASecond = { seconds: -1, nanoseconds: 500_000_000 }
+    out = toNanoseconds negativeHalfASecond
+    out == -500_000_000
+
+expect
+    out = toNanoseconds min
+    out == Num.minI64 |> Num.toI128 |> Conversion.secondsToNanoseconds
+
+expect
+    out = toNanoseconds max
+    out == Num.maxI64 |> Num.toI128 |> Conversion.secondsToNanoseconds |> Num.add 999_999_999
+
+## Get the number of whole microseconds in the duration, rounded towards zero.
+toWholeMicroseconds : Duration -> I64
+toWholeMicroseconds = \duration ->
+    Conversion.secondsToMicroseconds duration.seconds + Num.toI64 (Conversion.nanosecondsToWholeMicroseconds duration.nanoseconds)
+
+expect
+    out = toWholeMicroseconds zero
+    out == 0
+
+expect
+    halfASecond = { seconds: 0, nanoseconds: 500_000_000 }
+    out = toWholeMicroseconds halfASecond
+    out == 500_000
+
+expect
+    oneSecond = { seconds: 1, nanoseconds: 0 }
+    out = toWholeMicroseconds oneSecond
+    out == 1_000_000
+
+expect
+    oneAndAHalfSeconds = { seconds: 1, nanoseconds: 500_000_000 }
+    out = toWholeMicroseconds oneAndAHalfSeconds
+    out == 1_500_000
+
+expect
+    negativeOneSecond = { seconds: -1, nanoseconds: 0 }
+    out = toWholeMicroseconds negativeOneSecond
+    out == -1_000_000
+
+expect
+    negativeHalfASecond = { seconds: -1, nanoseconds: 500_000_000 }
+    out = toWholeMicroseconds negativeHalfASecond
+    out == -500_000
+
+## Get the number of whole milliseconds in the duration, rounded towards zero.
+toWholeMilliseconds : Duration -> I64
+toWholeMilliseconds = \duration ->
+    Conversion.secondsToMilliseconds duration.seconds + Conversion.nanosecondsToWholeMilliseconds (Num.toI64 duration.nanoseconds)
+
+expect
+    out = toWholeMilliseconds zero
+    out == 0
+
+expect
+    halfASecond = { seconds: 0, nanoseconds: 500_000_000 }
+    out = toWholeMilliseconds halfASecond
+    out == 500
+
+expect
+    oneSecond = { seconds: 1, nanoseconds: 0 }
+    out = toWholeMilliseconds oneSecond
+    out == 1_000
+
+expect
+    oneAndAHalfSeconds = { seconds: 1, nanoseconds: 500_000_000 }
+    out = toWholeMilliseconds oneAndAHalfSeconds
+    out == 1_500
+
+expect
+    negativeOneSecond = { seconds: -1, nanoseconds: 0 }
+    out = toWholeMilliseconds negativeOneSecond
+    out == -1_000
+
+expect
+    negativeHalfASecond = { seconds: -1, nanoseconds: 500_000_000 }
+    out = toWholeMilliseconds negativeHalfASecond
+    out == -500
+
+## Get the number of whole seconds in the duration, rounded towards zero.
+toWholeSeconds : Duration -> I64
+toWholeSeconds = \duration ->
+    if (Num.isNegative duration.seconds) && (Num.isPositive duration.nanoseconds) then
+        duration.seconds + 1
+    else
+        duration.seconds
+
+expect
+    out = toWholeSeconds zero
+    out == 0
+
+expect
+    halfASecond = { seconds: 0, nanoseconds: 500_000_000 }
+    out = toWholeSeconds halfASecond
+    out == 0
+
+expect
+    oneSecond = { seconds: 1, nanoseconds: 0 }
+    out = toWholeSeconds oneSecond
+    out == 1
+
+expect
+    oneAndAHalfSeconds = { seconds: 1, nanoseconds: 500_000_000 }
+    out = toWholeSeconds oneAndAHalfSeconds
+    out == 1
+
+expect
+    negativeOneSecond = { seconds: -1, nanoseconds: 0 }
+    out = toWholeSeconds negativeOneSecond
+    out == -1
+
+expect
+    negativeHalfASecond = { seconds: -1, nanoseconds: 500_000_000 }
+    out = toWholeSeconds negativeHalfASecond
+    out == 0
+
+expect
+    out = toWholeSeconds min
+    out == Num.minI64
+
+## Get the number of whole minutes in the duration, rounded towards zero.
+toWholeMinutes : Duration -> I64
+toWholeMinutes = \duration -> duration |> toWholeSeconds |> Conversion.secondsToWholeMinutes
+
+expect
+    out = toWholeMinutes zero
+    out == 0
+
+expect
+    zeroAndABit = { seconds: 0, nanoseconds: 1 }
+    out = toWholeMinutes zeroAndABit
+    out == 0
+
+expect
+    oneMinute = { seconds: 60, nanoseconds: 0 }
+    out = toWholeMinutes oneMinute
+    out == 1
+
+expect
+    oneMinuteAndABit = { seconds: 90, nanoseconds: 1 }
+    out = toWholeMinutes oneMinuteAndABit
+    out == 1
+
+expect
+    negativeOneMinute = { seconds: -60, nanoseconds: 0 }
+    out = toWholeMinutes negativeOneMinute
+    out == -1
+
+expect
+    negativeOneMinutePlusABit = { seconds: -60, nanoseconds: 1 }
+    out = toWholeMinutes negativeOneMinutePlusABit
+    out == 0
+
+## Get the number of whole hours in the duration, rounded towards zero.
+toWholeHours : Duration -> I64
+toWholeHours = \duration -> duration |> toWholeSeconds |> Conversion.secondsToWholeHours
+
+expect
+    out = toWholeHours zero
+    out == 0
+
+expect
+    zeroAndABit = { seconds: 0, nanoseconds: 1 }
+    out = toWholeHours zeroAndABit
+    out == 0
+
+expect
+    oneHour = { seconds: 3_600, nanoseconds: 0 }
+    out = toWholeHours oneHour
+    out == 1
+
+expect
+    oneHourAndABit = { seconds: 3_600, nanoseconds: 1 }
+    out = toWholeHours oneHourAndABit
+    out == 1
+
+expect
+    negativeOneHour = { seconds: -3_600, nanoseconds: 0 }
+    out = toWholeHours negativeOneHour
+    out == -1
+
+expect
+    negativeOneHourPlusABit = { seconds: -3_600, nanoseconds: 1 }
+    out = toWholeHours negativeOneHourPlusABit
+    out == 0
+
+## Get the number of whole days in the duration, rounded towards zero.
+toWholeDays : Duration -> I64
+toWholeDays = \duration -> duration |> toWholeSeconds |> Conversion.secondsToWholeDays
+
+expect
+    out = toWholeDays zero
+    out == 0
+
+expect
+    zeroAndABit = { seconds: 0, nanoseconds: 1 }
+    out = toWholeDays zeroAndABit
+    out == 0
+
+expect
+    oneDay = { seconds: 86_400, nanoseconds: 0 }
+    out = toWholeDays oneDay
+    out == 1
+
+expect
+    oneDayAndABit = { seconds: 86_400, nanoseconds: 1 }
+    out = toWholeDays oneDayAndABit
+    out == 1
+
+expect
+    negativeOneDay = { seconds: -86_400, nanoseconds: 0 }
+    out = toWholeDays negativeOneDay
+    out == -1
+
+expect
+    negativeOneDayPlusABit = { seconds: -86_400, nanoseconds: 1 }
+    out = toWholeDays negativeOneDayPlusABit
+    out == 0
+
+## Get the number of whole weeks in the duration, rounded towards zero.
+toWholeWeeks : Duration -> I64
+toWholeWeeks = \duration -> duration |> toWholeSeconds |> Conversion.secondsToWholeWeeks
+
+expect
+    out = toWholeWeeks zero
+    out == 0
+
+expect
+    zeroAndABit = { seconds: 0, nanoseconds: 1 }
+    out = toWholeWeeks zeroAndABit
+    out == 0
+
+expect
+    oneWeek = { seconds: 604_800, nanoseconds: 0 }
+    out = toWholeWeeks oneWeek
+    out == 1
+
+expect
+    oneWeekAndABit = { seconds: 604_800, nanoseconds: 1 }
+    out = toWholeWeeks oneWeekAndABit
+    out == 1
+
+expect
+    negativeOneWeek = { seconds: -604_800, nanoseconds: 0 }
+    out = toWholeWeeks negativeOneWeek
+    out == -1
+
+expect
+    negativeOneWeekPlusABit = { seconds: -604_800, nanoseconds: 1 }
+    out = toWholeWeeks negativeOneWeekPlusABit
+    out == 0
+
+## Add two durations together.
+add : Duration, Duration -> Duration
+add = \a, b ->
+    seconds = a.seconds + b.seconds
+    nanoseconds = a.nanoseconds + b.nanoseconds
+    if (nanoseconds >= (Conversion.secondsToNanoseconds 1)) then
+        { seconds: seconds + 1, nanoseconds: nanoseconds - (Conversion.secondsToNanoseconds 1) }
+    else
+        { seconds, nanoseconds }
+
+expect
+    oneSecond = { seconds: 1, nanoseconds: 0 }
+    twoSeconds = { seconds: 2, nanoseconds: 0 }
+    threeSeconds = { seconds: 3, nanoseconds: 0 }
+    out = add oneSecond twoSeconds
+    out == threeSeconds
+
+expect
+    oneAndAHalfSeconds = { seconds: 1, nanoseconds: 500_000_000 }
+    threeSeconds = { seconds: 3, nanoseconds: 0 }
+    out = add oneAndAHalfSeconds oneAndAHalfSeconds
+    out == threeSeconds
+
+expect
+    oneSecond = { seconds: 1, nanoseconds: 0 }
+    negativeTwoSeconds = { seconds: -2, nanoseconds: 0 }
+    negativeOneSecond = { seconds: -1, nanoseconds: 0 }
+    out = add oneSecond negativeTwoSeconds
+    out == negativeOneSecond

--- a/package/DateTimes/Duration.roc
+++ b/package/DateTimes/Duration.roc
@@ -1,4 +1,4 @@
-interface Duration
+interface DateTimes.Duration
     exposes [
         add,
         Duration,
@@ -21,8 +21,8 @@ interface Duration
         zero,
     ]
     imports [
-        Utils,
-        Conversion,
+        DateTimes.Utils,
+        DateTimes.Conversion,
     ]
 
 ## An amount of time measured to the nanosecond.

--- a/package/DateTimes/LICENCE
+++ b/package/DateTimes/LICENCE
@@ -1,0 +1,35 @@
+Copyright (c) 2023 Hannes
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any
+person obtaining a copy of this software, associated documentation and/or data
+(collectively the "Software"), free of charge and under any and all copyright
+rights in the Software, and any and all patent rights owned or freely
+licensable by each licensor hereunder covering either (i) the unmodified
+Software as contributed to or provided by such licensor, or (ii) the Larger
+Works (as defined below), to deal in both
+
+(a) the Software, and
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+one is included with the Software (each a “Larger Work” to which the Software
+is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create
+derivative works of, display, perform, and distribute the Software and make,
+use, sell, offer for sale, import, export, have made, and have sold the
+Software and the Larger Work(s), and to sublicense the foregoing rights on
+either these or other terms.
+
+This license is subject to the following condition:
+The above copyright notice and either this complete permission notice or at
+a minimum a reference to the UPL must be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/DateTimes/Math.roc
+++ b/package/DateTimes/Math.roc
@@ -1,0 +1,36 @@
+interface DateTimes.Math
+    exposes [
+    ]
+    imports [
+        DateTimes.Conversion.{
+            nanosecondsInASecond,
+            secondsInAnHour,
+            secondsInAMinute,
+        }
+        DateTimes.Duration,
+        DateTimes.Duration.{ Duration },
+        DateTimes.NaiveDate,
+        DateTimes.NaiveDate.{ NaiveDate },
+        DateTimes.NaiveDateTime,
+        DateTimes.NaiveDateTime.{ NaiveDateTime },
+        DateTimes.NaiveTime,
+        DateTimes.NaiveTime.{ NaiveTime },
+    ]
+
+timeToNanos : NaiveTime -> U128
+timeToNanos = \time ->
+    hNanos = time.hour * secondsInAnHour * nanosecondsInASecond |> Num.toU128
+    mNanos = time.minute * secondsInAMinute * nanosecondsInASecond |> Num.toU128
+    sNanos = time.second * nanosecondsInASecond |> Num.toU128
+    hNanos + mNanos + sNanos + Num.toU128 nanoSecondsInASecond
+
+dateToNanos : NaiveDate -> U128
+dateToNanos = \date ->
+    yNanos = date.year * secondsInAYear * nanosecondsInASecond |> Num.toU128
+    mNanos = date.month * secondsInAMonth * nanosecondsInASecond |> Num.toU128
+    dNanos = date.day * secondsInADay * nanosecondsInASecond |> Num.toU128
+    yNanos + mNanos + dNanos
+
+
+timeDifference : NaiveTime, NaiveTime -> Duration
+timeDifference = \time1, time2 -> Duration.fromSeconds

--- a/package/DateTimes/NaiveDate.roc
+++ b/package/DateTimes/NaiveDate.roc
@@ -1,4 +1,4 @@
-interface NaiveDate
+interface DateTimes.NaiveDate
     exposes [
         NaiveDate,
         fromYmd,
@@ -14,8 +14,8 @@ interface NaiveDate
         getMonth,
     ]
     imports [
-        Utils,
-        NaiveTime.{ NaiveTime, midnight },
+        DateTimes.Utils,
+        DateTimes.NaiveTime.{ NaiveTime, midnight },
     ]
 
 ## A date in the Gregorian calendar without a timezone.

--- a/package/DateTimes/NaiveDate.roc
+++ b/package/DateTimes/NaiveDate.roc
@@ -1,0 +1,278 @@
+interface NaiveDate
+    exposes [
+        NaiveDate,
+        fromYmd,
+        toIsoStr,
+        withNaiveTime,
+        toYmd,
+        unixEpoch,
+        firstDayOfCE,
+        fromOrdinalDate,
+        fromDaysSinceCE,
+        getDay,
+        getYear,
+        getMonth,
+    ]
+    imports [
+        Utils,
+        NaiveTime.{ NaiveTime, midnight },
+    ]
+
+## A date in the Gregorian calendar without a timezone.
+##
+## Stored as an ISO 8601 ordinal date, i.e. year and day of year
+## Dates before the start of the Gregorian calendar are extrapolated, so be careful with historical dates.
+## Years are 1 indexed to match the Common Era, i.e. year 1 is 1 CE, year 0 is 1 BCE, year -1 is 2 BCE, etc.
+## Day of the year is 0 indexed, i.e. 0 is the first day of the year.
+NaiveDate : { year : I64, dayOfYear : U16 }
+
+# Constructors
+
+## The Unix epoch, 1970-01-01.
+unixEpoch : NaiveDate
+unixEpoch = { year: 1970, dayOfYear: 0 }
+
+## The first day of the common era, 0001-01-01.
+firstDayOfCE : NaiveDate
+firstDayOfCE = { year: 1, dayOfYear: 0 }
+
+## Convert a year, month, and day to a NaiveDate.
+fromYmd : I64, U8, U8 -> Result NaiveDate [InvalidMonth, InvalidDay]
+fromYmd = \year, month, day ->
+    if month == 0 || month > 12 then
+        Err InvalidMonth
+    else
+        nDaysInMonth = Utils.nDaysInMonthOfYear month year |> Utils.unwrap "This should never happen, because we already checked that the month is valid."
+        if day == 0 || day > nDaysInMonth then
+            Err InvalidDay
+        else
+            dayOfYear =
+                Utils.nDaysInEachMonthOfYear year
+                |> List.map Num.toU16
+                |> List.sublist { start: 0, len: Num.intCast month }
+                |> List.sum
+                |> Num.add (Num.toU16 day)
+                |> Num.sub 1
+            Ok { year, dayOfYear }
+
+expect
+    out = fromYmd 1970 1 1
+    out == Ok unixEpoch
+
+expect
+    out = fromYmd 1 1 1
+    out == Ok firstDayOfCE
+
+expect
+    out = fromYmd 2023 1 1
+    out == Ok { year: 2023, dayOfYear: 0 }
+
+expect
+    out = fromYmd 1970 1 1
+    out == Ok { year: 1970, dayOfYear: 0 }
+
+expect
+    out = fromYmd 2023 12 31
+    out == Ok { year: 2023, dayOfYear: 364 }
+
+expect
+    out = fromYmd 2023 13 1
+    out == Err InvalidMonth
+
+## Convert a year and day of year to a NaiveDate.
+##
+## The first day of the year is 1st January.
+## Trying to convert the 0th day of the year or a day after the last day of the year returns an InvalidDayOfYear error.
+fromOrdinalDate : I64, U16 -> Result NaiveDate [InvalidDayOfYear]
+fromOrdinalDate = \year, dayOfYear ->
+    if dayOfYear == 0 || dayOfYear > (Utils.nDaysInYear year) then
+        Err InvalidDayOfYear
+    else
+        Ok { year: year, dayOfYear: dayOfYear - 1 }
+
+expect
+    out = fromOrdinalDate 1970 1
+    out == Ok unixEpoch
+
+expect
+    out = fromOrdinalDate 1 1
+    out == Ok firstDayOfCE
+
+expect
+    out = fromOrdinalDate 1 0 # 0th day of 1 CE
+    out == Err InvalidDayOfYear
+
+expect
+    out = fromOrdinalDate 1 365 # 31st December 1 CE
+    out == Ok { year: 1, dayOfYear: 364 }
+
+expect
+    out = fromOrdinalDate 1 366 # Day after the last day of 1 CE
+    out == Err InvalidDayOfYear
+
+expect
+    out = fromOrdinalDate 4 366 # 31st December 4 CE
+    out == Ok { year: 4, dayOfYear: 365 }
+
+expect
+    out = fromOrdinalDate 4 367 # Day after the last day of 4 CE
+    out == Err InvalidDayOfYear
+
+expect
+    out = fromOrdinalDate 1 59 # 28th February 1 CE
+    out == Ok { year: 1, dayOfYear: 58 }
+
+## Convert a number of days since the Common Era to a NaiveDate.
+##
+## The zeroth day of the Common Era is 31st December, 1 BCE, and the first day of the Common Era is 1st January, 1 CE.
+fromDaysSinceCE : U64 -> NaiveDate
+fromDaysSinceCE = \daysSinceCE ->
+    if daysSinceCE == 0 then
+        { year: 0, dayOfYear: 365 }
+    else
+        daysSinceCEIndex = daysSinceCE - 1 + 366
+        yearUpperBound = (daysSinceCEIndex // 365) + 2 # Just to be safe
+        daysInEachYear =
+            List.range { start: At 0, end: At yearUpperBound }
+            |> List.map Utils.nDaysInYear
+            |> List.map Num.toU64
+        { quotient: year, remainder: dayOfYearIndex } = Utils.subtractWhileGreaterThanZero daysSinceCEIndex daysInEachYear
+        dayOfYear = dayOfYearIndex |> Num.add 1 |> Num.toU16
+        fromOrdinalDate (Num.toI64 year) dayOfYear
+        |> Utils.unwrap "This should never happen because we already checked that the day of the year is valid."
+
+expect
+    out = fromDaysSinceCE 0
+    out
+    == (
+        fromYmd 0 12 31
+        |> Utils.unwrap "This should never happen because the date was hardcoded."
+    )
+
+expect
+    out = fromDaysSinceCE 1
+    out
+    == (
+        fromYmd 1 1 1
+        |> Utils.unwrap "This should never happen because the date was hardcoded."
+    )
+
+expect
+    out = fromDaysSinceCE 365
+    out
+    == (
+        fromYmd 1 12 31
+        |> Utils.unwrap "This should never happen because the date was hardcoded."
+    )
+
+expect
+    out = fromDaysSinceCE 366
+    out
+    == (
+        fromYmd 2 1 1
+        |> Utils.unwrap "This should never happen because the date was hardcoded."
+    )
+
+expect
+    nDaysInFirstFourYearsOfCE =
+        List.range { start: At 1, end: At 4 }
+        |> List.map Utils.nDaysInYear
+        |> List.map Num.toU64
+        |> List.sum
+    out = fromDaysSinceCE nDaysInFirstFourYearsOfCE
+    out == (fromYmd 4 12 31 |> Result.withDefault unixEpoch)
+
+# Serialise
+
+## Serialise a date to ISO format.
+toIsoStr : NaiveDate -> Str
+toIsoStr = \naiveDate ->
+    { year, month, day } = toYmd naiveDate
+    yearStr = year |> Utils.padIntegerToLength 4
+    monthStr = month |> Utils.padIntegerToLength 2
+    dayStr = day |> Utils.padIntegerToLength 2
+    "\(yearStr)-\(monthStr)-\(dayStr)"
+
+expect
+    out = toIsoStr unixEpoch
+    out == "1970-01-01"
+
+expect
+    out = toIsoStr firstDayOfCE
+    out == "0001-01-01"
+
+# Methods
+
+## Convert a NaiveDate to a year, month, and day.
+toYmd : NaiveDate -> { year : I64, month : U8, day : U8 }
+toYmd = \naiveDate ->
+    { quotient: month, remainder: dayIndex } = Utils.subtractWhileGreaterThanZero naiveDate.dayOfYear (Utils.nDaysInEachMonthOfYear naiveDate.year |> List.map Num.toU16)
+    { year: naiveDate.year, month: Num.toU8 month, day: Num.toU8 dayIndex + 1 }
+
+expect
+    out = toYmd unixEpoch
+    out == { year: 1970, month: 1, day: 1 }
+
+expect
+    out = toYmd firstDayOfCE
+    out == { year: 1, month: 1, day: 1 }
+
+expect
+    out = toYmd { year: 1, dayOfYear: 364 } # 31st December 1 CE
+    out == { year: 1, month: 12, day: 31 }
+
+expect
+    out = toYmd { year: 4, dayOfYear: 365 } # 31st December 4 CE
+    out == { year: 4, month: 12, day: 31 }
+
+expect
+    out = toYmd { year: 1, dayOfYear: 58 } # 28th February 1 CE
+    out == { year: 1, month: 2, day: 28 }
+
+## Get the year of a NaiveDate.
+getYear : NaiveDate -> I64
+getYear = \naiveDate -> naiveDate.year
+
+expect
+    out = getYear unixEpoch
+    out == 1970
+
+expect
+    out = getYear firstDayOfCE
+    out == 1
+
+## Get the month of a NaiveDate.
+getMonth : NaiveDate -> U8
+getMonth = \naiveDate -> (toYmd naiveDate).month
+
+expect
+    out = getMonth unixEpoch
+    out == 1
+
+expect
+    out = getMonth firstDayOfCE
+    out == 1
+
+## Get the day of a NaiveDate.
+getDay : NaiveDate -> U8
+getDay = \naiveDate -> (toYmd naiveDate).day
+
+expect
+    out = getDay unixEpoch
+    out == 1
+
+expect
+    out = getDay firstDayOfCE
+    out == 1
+
+## Add a NaiveTime to a NaiveDate.
+withNaiveTime : NaiveDate, NaiveTime -> _
+withNaiveTime = \naiveDate, naiveTime -> { naiveDate: naiveDate, naiveTime: naiveTime }
+
+expect
+    out = withNaiveTime unixEpoch midnight
+    out == { naiveDate: unixEpoch, naiveTime: midnight }
+
+expect
+    out = withNaiveTime firstDayOfCE midnight
+    out == { naiveDate: firstDayOfCE, naiveTime: midnight }

--- a/package/DateTimes/NaiveDateTime.roc
+++ b/package/DateTimes/NaiveDateTime.roc
@@ -1,4 +1,4 @@
-interface NaiveDateTime
+interface DateTimes.NaiveDateTime
     exposes [
         NaiveDateTime,
         unixEpoch,
@@ -6,31 +6,31 @@ interface NaiveDateTime
         fromYmdhms,
     ]
     imports [
-        NaiveDate,
-        NaiveDate.{ NaiveDate },
-        NaiveTime,
-        NaiveTime.{ NaiveTime },
-        Utils,
+        DateTimes.NaiveDate,
+        DateTimes.NaiveDate.{ NaiveDate },
+        DateTimes.NaiveTime,
+        DateTimes.NaiveTime.{ NaiveTime },
+        DateTimes.Utils,
     ]
 
 ## A date and time without a timezone.
-NaiveDateTime : { naiveDate : NaiveDate.NaiveDate, naiveTime : NaiveTime.NaiveTime }
+NaiveDateTime : { naiveDate : NaiveDate, naiveTime : NaiveTime }
 
 ## The Unix epoch, 1970-01-01T00:00:00.
 unixEpoch : NaiveDateTime
-unixEpoch = { naiveDate: NaiveDate.unixEpoch, naiveTime: NaiveTime.midnight }
+unixEpoch = { naiveDate: DateTimes.NaiveDate.unixEpoch, naiveTime: DateTimes.NaiveTime.midnight }
 
 # Constructors
 
 ## Convert a year, month, day, hour, minute, second, and nanosecond to a NaiveDateTime.
 fromYmdhmsn : I64, U8, U8, U8, U8, U8, U32 -> Result NaiveDateTime [InvalidDateTime]
 fromYmdhmsn = \year, month, day, hour, minute, second, nanosecond ->
-    naiveTime = NaiveTime.fromHmsn hour minute second nanosecond
-    naiveDate = NaiveDate.fromYmd year month day
+    naiveTime = DateTimes.NaiveTime.fromHmsn hour minute second nanosecond
+    naiveDate = DateTimes.NaiveDate.fromYmd year month day
     if (Result.isOk naiveTime) && (Result.isOk naiveDate) then
         Ok {
-            naiveDate: naiveDate |> Result.withDefault NaiveDate.unixEpoch,
-            naiveTime: naiveTime |> Result.withDefault NaiveTime.midnight,
+            naiveDate: naiveDate |> Result.withDefault DateTimes.NaiveDate.unixEpoch,
+            naiveTime: naiveTime |> Result.withDefault DateTimes.NaiveTime.midnight,
         }
     else
         Err InvalidDateTime
@@ -46,8 +46,8 @@ expect
     out = fromYmdhmsn year month day hour minute second nanosecond
     out
     == Ok {
-        naiveDate: NaiveDate.fromYmd year month day |> Utils.unwrap "This should never happen because the date was hardcoded.",
-        naiveTime: NaiveTime.fromHmsn hour minute second nanosecond |> Utils.unwrap "This should never happen because the date was hardcoded.",
+        naiveDate: DateTimes.NaiveDate.fromYmd year month day |> DateTimes.Utils.unwrap "This should never happen because the date was hardcoded.",
+        naiveTime: DateTimes.NaiveTime.fromHmsn hour minute second nanosecond |> DateTimes.Utils.unwrap "This should never happen because the date was hardcoded.",
     }
 
 ## Convert a year, month, day, hour, minute, and second to a NaiveDateTime.
@@ -65,10 +65,10 @@ expect
     out = fromYmdhms year month day hour minute second
     out
     == Ok {
-        naiveDate: NaiveDate.fromYmd year month day
-        |> Utils.unwrap "This should never happen because the date was hardcoded.",
-        naiveTime: NaiveTime.fromHms hour minute second
-        |> Utils.unwrap "This should never happen because the date was hardcoded.",
+        naiveDate: DateTimes.NaiveDate.fromYmd year month day
+        |> DateTimes.Utils.unwrap "This should never happen because the date was hardcoded.",
+        naiveTime: DateTimes.NaiveTime.fromHms hour minute second
+        |> DateTimes.Utils.unwrap "This should never happen because the date was hardcoded.",
     }
 
 # Methods

--- a/package/DateTimes/NaiveDateTime.roc
+++ b/package/DateTimes/NaiveDateTime.roc
@@ -1,0 +1,78 @@
+interface NaiveDateTime
+    exposes [
+        NaiveDateTime,
+        unixEpoch,
+        fromYmdhmsn,
+        fromYmdhms,
+    ]
+    imports [
+        NaiveDate,
+        NaiveDate.{ NaiveDate },
+        NaiveTime,
+        NaiveTime.{ NaiveTime },
+        Utils,
+    ]
+
+## A date and time without a timezone.
+NaiveDateTime : { naiveDate : NaiveDate.NaiveDate, naiveTime : NaiveTime.NaiveTime }
+
+## The Unix epoch, 1970-01-01T00:00:00.
+unixEpoch : NaiveDateTime
+unixEpoch = { naiveDate: NaiveDate.unixEpoch, naiveTime: NaiveTime.midnight }
+
+# Constructors
+
+## Convert a year, month, day, hour, minute, second, and nanosecond to a NaiveDateTime.
+fromYmdhmsn : I64, U8, U8, U8, U8, U8, U32 -> Result NaiveDateTime [InvalidDateTime]
+fromYmdhmsn = \year, month, day, hour, minute, second, nanosecond ->
+    naiveTime = NaiveTime.fromHmsn hour minute second nanosecond
+    naiveDate = NaiveDate.fromYmd year month day
+    if (Result.isOk naiveTime) && (Result.isOk naiveDate) then
+        Ok {
+            naiveDate: naiveDate |> Result.withDefault NaiveDate.unixEpoch,
+            naiveTime: naiveTime |> Result.withDefault NaiveTime.midnight,
+        }
+    else
+        Err InvalidDateTime
+
+expect
+    year = 7
+    month = 6
+    day = 5
+    hour = 4
+    minute = 3
+    second = 2
+    nanosecond = 1
+    out = fromYmdhmsn year month day hour minute second nanosecond
+    out
+    == Ok {
+        naiveDate: NaiveDate.fromYmd year month day |> Utils.unwrap "This should never happen because the date was hardcoded.",
+        naiveTime: NaiveTime.fromHmsn hour minute second nanosecond |> Utils.unwrap "This should never happen because the date was hardcoded.",
+    }
+
+## Convert a year, month, day, hour, minute, and second to a NaiveDateTime.
+fromYmdhms : I64, U8, U8, U8, U8, U8 -> Result NaiveDateTime [InvalidDateTime]
+fromYmdhms = \year, month, day, hour, minute, second ->
+    fromYmdhmsn year month day hour minute second 0
+
+expect
+    year = 6
+    month = 5
+    day = 4
+    hour = 3
+    minute = 2
+    second = 1
+    out = fromYmdhms year month day hour minute second
+    out
+    == Ok {
+        naiveDate: NaiveDate.fromYmd year month day
+        |> Utils.unwrap "This should never happen because the date was hardcoded.",
+        naiveTime: NaiveTime.fromHms hour minute second
+        |> Utils.unwrap "This should never happen because the date was hardcoded.",
+    }
+
+# Methods
+
+# ## add
+# add : NaiveDateTime, Duration -> NaiveDateTime
+# add = \naiveDateTime, duration ->

--- a/package/DateTimes/NaiveTime.roc
+++ b/package/DateTimes/NaiveTime.roc
@@ -1,4 +1,4 @@
-interface NaiveTime
+interface DateTimes.NaiveTime
     exposes [
         NaiveTime,
         fromHms,
@@ -7,8 +7,8 @@ interface NaiveTime
         midnight,
     ]
     imports [
-        Utils.{ flooredIntegerDivisionAndModulus },
-        Conversion,
+        DateTimes.Utils.{ flooredIntegerDivisionAndModulus },
+        DateTimes.Conversion,
     ]
 
 ## A time of day, without a timezone.
@@ -64,9 +64,9 @@ expect
 ## Convert a number of seconds after midnight into a NaiveTime.
 fromSecondsAfterMidnight : U32, U32 -> Result NaiveTime [InvalidNumberOfSeconds, InvalidNanosecond]
 fromSecondsAfterMidnight = \seconds, nanoseconds ->
-    if (seconds >= (Conversion.daysToSeconds 1)) then
+    if (seconds >= (DateTimes.Conversion.daysToSeconds 1)) then
         Err InvalidNumberOfSeconds
-    else if (nanoseconds >= (Conversion.secondsToNanoseconds 1)) then
+    else if (nanoseconds >= (DateTimes.Conversion.secondsToNanoseconds 1)) then
         Err InvalidNanosecond
     else
         (hour, remainingSeconds) = flooredIntegerDivisionAndModulus seconds 24
@@ -198,14 +198,14 @@ expect
 ## withMicrosecond
 withMicrosecond : NaiveTime, U32 -> Result NaiveTime [InvalidNumberOfMicroseconds]
 withMicrosecond = \naiveTime, microsecond ->
-    if (microsecond >= (Conversion.secondsToMicroseconds 1)) then
+    if (microsecond >= (DateTimes.Conversion.secondsToMicroseconds 1)) then
         Err InvalidNumberOfMicroseconds
     else
         Ok {
             hour: naiveTime.hour,
             minute: naiveTime.minute,
             second: naiveTime.second,
-            nanosecond: Conversion.microsecondsToNanoseconds microsecond,
+            nanosecond: DateTimes.Conversion.microsecondsToNanoseconds microsecond,
         }
 
 expect
@@ -260,9 +260,9 @@ expect
 toIsoStr : NaiveTime -> Str
 toIsoStr = \naiveTime ->
     { hour, minute, second } = naiveTime
-    hourStr = hour |> Utils.padIntegerToLength 2
-    minuteStr = minute |> Utils.padIntegerToLength 2
-    secondStr = second |> Utils.padIntegerToLength 2
+    hourStr = hour |> DateTimes.Utils.padIntegerToLength 2
+    minuteStr = minute |> DateTimes.Utils.padIntegerToLength 2
+    secondStr = second |> DateTimes.Utils.padIntegerToLength 2
     "\(hourStr):\(minuteStr):\(secondStr)"
 
 expect

--- a/package/DateTimes/NaiveTime.roc
+++ b/package/DateTimes/NaiveTime.roc
@@ -1,0 +1,274 @@
+interface NaiveTime
+    exposes [
+        NaiveTime,
+        fromHms,
+        fromHmsn,
+        toIsoStr,
+        midnight,
+    ]
+    imports [
+        Utils.{ flooredIntegerDivisionAndModulus },
+        Conversion,
+    ]
+
+## A time of day, without a timezone.
+NaiveTime : { hour : U8, minute : U8, second : U8, nanosecond : U32 }
+
+# Constructors
+
+## Y'know, the time of day, or rather time of night.
+midnight : NaiveTime
+midnight = { hour: 0u8, minute: 0u8, second: 0u8, nanosecond: 0u32 }
+
+## Convert a number of hours, minutes, seconds, and nanoseconds into a NaiveTime.
+fromHmsn : U8, U8, U8, U32 -> Result NaiveTime [InvalidTime]
+fromHmsn = \hour, minute, second, nanosecond ->
+    if
+        (0 <= hour && hour < 24)
+        && (0 <= minute && minute < 60)
+        && (0 <= second && second < 60)
+        && (0 <= nanosecond && nanosecond < 1_000_000_000)
+    then
+        Ok { hour: hour, minute: minute, second: second, nanosecond: nanosecond }
+    else
+        Err InvalidTime
+
+expect
+    out = fromHmsn 4u8 3u8 2u8 1u32
+    out == Ok { hour: 4, minute: 3, second: 2, nanosecond: 1 }
+
+## Convert a number of hours, minutes, seconds, and milliseconds into a NaiveTime.
+fromHmsm : U8, U8, U8, U32 -> Result NaiveTime [InvalidTime]
+fromHmsm = \hour, minute, second, millisecond -> fromHmsn hour minute second (1_000_000 * millisecond)
+
+expect
+    out = fromHmsm 4 3 2 1
+    out == Ok { hour: 4, minute: 3, second: 2, nanosecond: 1_000_000u32 }
+
+## Convert a number of hours, minutes, seconds, and microseconds into a NaiveTime.
+fromHmsμ : U8, U8, U8, U32 -> Result NaiveTime [InvalidTime]
+fromHmsμ = \hour, minute, second, microsecond -> fromHmsn hour minute second (1000 * microsecond)
+
+expect
+    out = fromHmsμ 4 3 2 1
+    out == Ok { hour: 4, minute: 3, second: 2, nanosecond: 1000 }
+
+## Convert a number of hours, minutes, and seconds into a NaiveTime.
+fromHms : U8, U8, U8 -> Result NaiveTime [InvalidTime]
+fromHms = \hour, minute, second -> fromHmsn hour minute second 0u32
+
+expect
+    out = fromHms 4 3 2
+    out == Ok { hour: 4, minute: 3, second: 2, nanosecond: 0 }
+
+## Convert a number of seconds after midnight into a NaiveTime.
+fromSecondsAfterMidnight : U32, U32 -> Result NaiveTime [InvalidNumberOfSeconds, InvalidNanosecond]
+fromSecondsAfterMidnight = \seconds, nanoseconds ->
+    if (seconds >= (Conversion.daysToSeconds 1)) then
+        Err InvalidNumberOfSeconds
+    else if (nanoseconds >= (Conversion.secondsToNanoseconds 1)) then
+        Err InvalidNanosecond
+    else
+        (hour, remainingSeconds) = flooredIntegerDivisionAndModulus seconds 24
+        (minute, second) = flooredIntegerDivisionAndModulus remainingSeconds 60
+        Ok { hour: Num.toU8 hour, minute: Num.toU8 minute, second: Num.toU8 second, nanosecond: nanoseconds }
+
+expect fromSecondsAfterMidnight 0 0 == Ok midnight
+expect fromSecondsAfterMidnight 123_456_789 0 == Err InvalidNumberOfSeconds
+expect fromSecondsAfterMidnight 0 1_000_000_001 == Err InvalidNanosecond
+
+## Parses a string in the format "T?[HH]:?[MM]:?[SS].[sss]" to a NaiveTime.
+parseIsoStr : Str -> Result NaiveTime [InvalidIsoStr, InvalidTime]
+parseIsoStr = \isoStr ->
+    if Str.isEmpty isoStr then
+        Err InvalidIsoStr
+    else
+        startsWithT = isoStr |> Str.startsWith "T"
+        segments = (if startsWithT then (isoStr |> Str.replaceFirst "T" "") else isoStr) |> Str.split ":"
+        nSegments = List.len segments
+        (hours, minutes, seconds) =
+            if nSegments == 1 then
+                (Ok 1, Ok 2, Ok 3)
+            else if nSegments == 3 then
+                ((List.get segments 0) |> Result.try Str.toU8, (List.get segments 1) |> Result.try Str.toU8, (List.get segments 2) |> Result.try Str.toU8)
+            else
+                (Err InvalidIsoStr, Err InvalidIsoStr, Err InvalidIsoStr)
+        if (Result.isOk hours) && (Result.isOk minutes) && (Result.isOk seconds) then
+            fromHms (Result.withDefault hours 0) (Result.withDefault minutes 0) (Result.withDefault seconds 0)
+        else
+            Err InvalidIsoStr
+
+expect
+    out = parseIsoStr "01:02:03"
+    out == (fromHms 1 2 3)
+
+expect
+    out = parseIsoStr "T01:02:03"
+    out == (fromHms 1 2 3)
+
+expect
+    out = parseIsoStr "01:02:03:04"
+    out == Err InvalidIsoStr
+
+expect
+    out = parseIsoStr "T01:02:03:04"
+    out == Err InvalidIsoStr
+
+# expect
+#     out = parseIsoStr "01:02:03.456"
+#     out == (fromHmsm 1 2 3 456)
+
+# expect
+#     out = parseIsoStr "T01:02:03.456"
+#     out == (fromHmsm 1 2 3 456)
+
+expect
+    out = parseIsoStr "010203"
+    out == (fromHms 1 2 3)
+
+expect
+    out = parseIsoStr "T010203"
+    out == (fromHms 1 2 3)
+
+# Methods
+
+## withHour
+withHour : NaiveTime, U8 -> Result NaiveTime [InvalidNumberOfHours]
+withHour = \naiveTime, hour ->
+    if (hour >= 24) then
+        Err InvalidNumberOfHours
+    else
+        Ok {
+            hour: hour,
+            minute: naiveTime.minute,
+            second: naiveTime.second,
+            nanosecond: naiveTime.nanosecond,
+        }
+
+expect
+    out = { hour: 1, minute: 2, second: 3, nanosecond: 4 } |> withHour 7
+    out == Ok { hour: 7, minute: 2, second: 3, nanosecond: 4 }
+
+expect
+    out = midnight |> withHour 24
+    out == Err InvalidNumberOfHours
+
+## withMinute
+withMinute : NaiveTime, U8 -> Result NaiveTime [InvalidNumberOfMinutes]
+withMinute = \naiveTime, minute ->
+    if (minute >= 60) then
+        Err InvalidNumberOfMinutes
+    else
+        Ok {
+            hour: naiveTime.hour,
+            minute: minute,
+            second: naiveTime.second,
+            nanosecond: naiveTime.nanosecond,
+        }
+
+expect
+    out = { hour: 1, minute: 2, second: 3, nanosecond: 4 } |> withMinute 7
+    out == Ok { hour: 1, minute: 7, second: 3, nanosecond: 4 }
+
+expect
+    out = midnight |> withMinute 60
+    out == Err InvalidNumberOfMinutes
+
+## withSecond
+withSecond : NaiveTime, U8 -> Result NaiveTime [InvalidNumberOfSeconds]
+withSecond = \naiveTime, second ->
+    if (second >= 60) then
+        Err InvalidNumberOfSeconds
+    else
+        Ok {
+            hour: naiveTime.hour,
+            minute: naiveTime.minute,
+            second: second,
+            nanosecond: naiveTime.nanosecond,
+        }
+
+expect
+    out = { hour: 1, minute: 2, second: 3, nanosecond: 4 } |> withSecond 7
+    out == Ok { hour: 1, minute: 2, second: 7, nanosecond: 4 }
+
+expect
+    out = midnight |> withSecond 60
+    out == Err InvalidNumberOfSeconds
+
+## withMicrosecond
+withMicrosecond : NaiveTime, U32 -> Result NaiveTime [InvalidNumberOfMicroseconds]
+withMicrosecond = \naiveTime, microsecond ->
+    if (microsecond >= (Conversion.secondsToMicroseconds 1)) then
+        Err InvalidNumberOfMicroseconds
+    else
+        Ok {
+            hour: naiveTime.hour,
+            minute: naiveTime.minute,
+            second: naiveTime.second,
+            nanosecond: Conversion.microsecondsToNanoseconds microsecond,
+        }
+
+expect
+    out = { hour: 1, minute: 2, second: 3, nanosecond: 4 } |> withMicrosecond 7
+    out == Ok { hour: 1, minute: 2, second: 3, nanosecond: 7_000 }
+
+expect
+    out = midnight |> withMicrosecond 1_000_000
+    out == Err InvalidNumberOfMicroseconds
+
+## withNanosecond
+withNanosecond : NaiveTime, U32 -> Result NaiveTime [InvalidNanosecond]
+withNanosecond = \naiveTime, nanosecond ->
+    if (nanosecond >= 1_000_000_000) then
+        Err InvalidNanosecond
+    else
+        Ok {
+            hour: naiveTime.hour,
+            minute: naiveTime.minute,
+            second: naiveTime.second,
+            nanosecond: nanosecond,
+        }
+
+expect
+    out = { hour: 1, minute: 2, second: 3, nanosecond: 4 } |> withNanosecond 7
+    out == Ok { hour: 1, minute: 2, second: 3, nanosecond: 7 }
+
+expect
+    out = midnight |> withNanosecond 1_000_000_000
+    out == Err InvalidNanosecond
+
+## withNaiveDate
+withNaiveDate : NaiveTime, _ -> _
+withNaiveDate = \naiveTime, naiveDate -> { naiveDate: naiveDate, naiveTime: naiveTime }
+
+expect
+    out = midnight |> withNaiveDate { year: 1970, month: 1, day: 1 }
+    out == { naiveDate: { year: 1970, month: 1, day: 1 }, naiveTime: midnight }
+
+# ## add
+# add : NaiveTime, Duration -> NaiveTime
+# add = \naiveTime, duration -> {
+#     hour: naiveTime.hour + (Duration.getHours duration),
+#     minute: naiveTime.minute + Duration.getMinutes duration,
+#     second: naiveTime.second + Duration.getSeconds duration,
+#     nanosecond: naiveTime.nanosecond + Duration.getNanoseconds duration,
+# }
+
+# Serialise
+
+## toIsoStr
+toIsoStr : NaiveTime -> Str
+toIsoStr = \naiveTime ->
+    { hour, minute, second } = naiveTime
+    hourStr = hour |> Utils.padIntegerToLength 2
+    minuteStr = minute |> Utils.padIntegerToLength 2
+    secondStr = second |> Utils.padIntegerToLength 2
+    "\(hourStr):\(minuteStr):\(secondStr)"
+
+expect
+    out = midnight |> toIsoStr
+    out == "00:00:00"
+
+expect
+    out = { hour: 1, minute: 2, second: 3, nanosecond: 4 } |> toIsoStr
+    out == "01:02:03"

--- a/package/DateTimes/README.md
+++ b/package/DateTimes/README.md
@@ -1,0 +1,9 @@
+# Roc DateTimes
+
+A work in progress library for working with dates and times in Roc.
+
+Based on the [Chrono](https://docs.rs/chrono/latest/chrono/) library for Rust.
+
+## Licence
+
+This repository is released under the [UPL licence](./LICENCE) and is based on the [chrono](https://docs.rs/chrono/latest/chrono/) library which dual licenced under the [MIT Licence](./LICENCE-chrono-mit) and the [Apache Licence 2.0](./LICENCE-chrono-apache-2).

--- a/package/DateTimes/Utils.roc
+++ b/package/DateTimes/Utils.roc
@@ -1,4 +1,4 @@
-interface Utils
+interface DateTimes.Utils
     exposes [
         flooredIntegerDivisionAndModulus,
         nDaysInMonthOfYear,

--- a/package/DateTimes/Utils.roc
+++ b/package/DateTimes/Utils.roc
@@ -1,0 +1,225 @@
+interface Utils
+    exposes [
+        flooredIntegerDivisionAndModulus,
+        nDaysInMonthOfYear,
+        nDaysInEachMonthOfYear,
+        padIntegerToLength,
+        subtractWhileGreaterThanZero,
+        nDaysInYear,
+        unwrap,
+        cumulativeSum,
+    ]
+    imports []
+
+# Functions
+
+## unwrap
+unwrap : Result a _, Str -> a
+unwrap = \x, message ->
+    when x is
+        Ok v -> v
+        Err _ -> crash message
+
+## cumulativeSum
+cumulativeSum : List (Num a) -> List (Num a)
+cumulativeSum = \xs ->
+    xs
+    |> List.walk [0] (\accumulator, x -> accumulator |> List.append ((List.last accumulator |> unwrap "This can never happen because the list always has at least one element") + x))
+
+## Divide the numerator by the denominator, returning the quotient and remainder.
+##
+## Division is rounded towards zero, so if `flooredIntegerDivisionAndModulus a b == (q, r)`, then `a == b * q + r`.
+# flooredIntegerDivisionAndModulus : Num, Num -> (Num, Num)
+flooredIntegerDivisionAndModulus = \numerator, denominator ->
+    quotient = numerator // denominator
+    remainder = numerator - denominator * quotient
+    (quotient, remainder)
+
+expect
+    out = flooredIntegerDivisionAndModulus 11 5
+    out == (2, 1)
+
+expect
+    out = flooredIntegerDivisionAndModulus -11 5
+    out == (-2, -1)
+
+## padLeft
+# padLeft : Str , Str, U8 -> Str
+padLeft = \x, padWith, desiredLength ->
+    currentLength = Str.countUtf8Bytes x # TODO replace with proper unicode length when available
+    if currentLength >= desiredLength then
+        x
+    else
+        extendBy = desiredLength - currentLength
+        x |> Str.withPrefix (Str.repeat padWith extendBy)
+
+expect
+    out = padLeft "hello" " " 10
+    out == "     hello"
+
+## padIntegerToLength
+# padIntegerToLength : U8 , U8 -> Str
+padIntegerToLength = \x, desiredLength ->
+    xStr = Num.toStr x
+    padLeft xStr "0" desiredLength
+
+expect
+    out = padIntegerToLength 5 2
+    out == "05"
+
+expect
+    out = padIntegerToLength 123 2
+    out == "123"
+
+## divides
+# divides : I64 , I64 -> Bool
+divides = \a, b -> a % b == 0
+
+expect
+    out = divides 10 2
+    out == Bool.true
+
+expect
+    out = divides 11 2
+    out == Bool.false
+
+## isLeapYear
+# isLeapYear : I64 -> Bool
+isLeapYear = \year -> (divides year 4) && ((Bool.not (divides year 100)) || (divides year 400))
+
+expect
+    out = isLeapYear 2001
+    out == Bool.false
+
+expect
+    out = isLeapYear 2004
+    out == Bool.true
+
+expect
+    out = isLeapYear 1900
+    out == Bool.false
+
+expect
+    out = isLeapYear 2000
+    out == Bool.true
+
+expect
+    out = isLeapYear 0 # 1 BCE
+    out == Bool.true
+
+expect
+    out = isLeapYear -1 # 2 BCE
+    out == Bool.false
+
+expect
+    out = isLeapYear -4 # 5 BCE
+    out == Bool.true
+
+## nDaysInEachMonthOfYear
+nDaysInEachMonthOfYear : I64 -> List U8
+nDaysInEachMonthOfYear = \year -> [0, 31, 28 + (if isLeapYear year then 1 else 0), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+## nDaysInMonthOfYear
+nDaysInMonthOfYear : U8, I64 -> Result U8 [InvalidMonth]
+nDaysInMonthOfYear = \month, year ->
+    year
+    |> nDaysInEachMonthOfYear
+    |> List.get (Num.intCast month)
+    |> Result.mapErr \_ -> InvalidMonth
+
+expect
+    out = nDaysInMonthOfYear 1 1
+    out == Ok 31
+
+expect
+    out = nDaysInMonthOfYear 2 1
+    out == Ok 28
+
+expect
+    out = nDaysInMonthOfYear 2 4
+    out == Ok 29
+
+expect
+    out = nDaysInMonthOfYear 13 1
+    out == Err InvalidMonth
+
+## nDaysInYear
+# nDaysInYear : I64 -> U16
+nDaysInYear = \year -> if isLeapYear year then 366u16 else 365u16
+
+expect
+    out = nDaysInYear 2004
+    out == 366u16
+
+expect
+    out = nDaysInYear 1900
+    out == 365u16
+
+expect
+    out = nDaysInYear 2000
+    out == 366u16
+
+subtractWhileGreaterThanZero : Num a, List (Num a) -> { quotient : Num a, remainder : Num a }
+subtractWhileGreaterThanZero = \numerator, list ->
+    List.walkUntil
+        list
+        { quotient: 0, remainder: numerator }
+        (
+            \{ quotient, remainder }, toSubtract ->
+                if remainder >= toSubtract then
+                    Continue { quotient: quotient + 1, remainder: remainder - toSubtract }
+                else
+                    Break { quotient: quotient, remainder: remainder }
+        )
+
+expect
+    out = subtractWhileGreaterThanZero 3 [1, 1, 1, 1]
+    out == { quotient: 3, remainder: 0 }
+
+expect
+    out = subtractWhileGreaterThanZero 3 []
+    out == { quotient: 0, remainder: 3 }
+
+expect
+    out = subtractWhileGreaterThanZero 3 [1, 1, 1]
+    out == { quotient: 3, remainder: 0 }
+
+expect
+    out = subtractWhileGreaterThanZero 3 [1, 2, 3, 4]
+    out == { quotient: 2, remainder: 0 }
+
+expect
+    out = subtractWhileGreaterThanZero 4 [1, 2, 3, 4]
+    out == { quotient: 2, remainder: 1 }
+
+# ## Convert the number of days into the 400 year cycle to a year and ordinal day of the year.
+# dayofYearMod400ToYearMod400AndDayOfYear : U16 -> {yearMod400: U16, dayOfYear: U16}
+# dayofYearMod400ToYearMod400AndDayOfYear = \dayOfYearMod400 ->
+#     nDaysInEachYearMod400 =
+#         List.range { start: At 1i64, end: At 400i64 }
+#         |> List.map Utils.nDaysInYear
+#     ( yearMod400, dayOfYear ) = subtractWhileGreaterThanZero dayOfYearMod400 nDaysInEachYearMod400
+#     { yearMod400: yearMod400 + 1, dayOfYear: dayOfYear + 1 }
+
+# cycleToYo = \cycle ->
+#     Pair yearMod400 ordinal0 = flooredIntegerDivisionAndModulus cycle 365
+#     delta  = List.get Constants.yearDeltas yearMod400 |> Result.withDefault -1
+#     Pair yearMod400 ordinal0 = if ordinal0 < delta then
+#         newYearMod400 = yearMod400 - 1
+#         newOrdinal0 = ordinal0 +  365 - (List.get Constants.yearDeltas newYearMod400 |> Result.withDefault -1)
+#         Pair newYearMod400 newOrdinal0
+#     else
+#         Pair yearMod400 (ordinal0 - delta)
+#     Pair yearMod400 (ordinal0+1)
+
+# fn cycle_to_yo(cycle: u32) -> (u32, u32) {
+#     let (mut year_mod_400, mut ordinal0) = div_rem(cycle, 365);
+#     let delta = u32::from(YEAR_DELTAS[year_mod_400 as usize]);
+#     if ordinal0 < delta {
+#         year_mod_400 -= 1;
+#         ordinal0 += 365 - u32::from(YEAR_DELTAS[year_mod_400 as usize]);
+#     } else {
+#         ordinal0 -= delta;
+#     }
+#     (year_mod_400, ordinal0 + 1)
+# }

--- a/package/DateTimes/main.roc
+++ b/package/DateTimes/main.roc
@@ -1,0 +1,8 @@
+package "DateTimes"
+    exposes [
+        Duration,
+        NaiveDate,
+        NaiveDateTime,
+        NaiveTime,
+    ]
+    packages {}

--- a/package/Duration.roc
+++ b/package/Duration.roc
@@ -1,0 +1,7 @@
+interface Duration
+    exposes [
+    ]
+    imports [
+    ]
+
+Duration : { seconds : I64, nanoseconds : U32 }

--- a/package/Tests.roc
+++ b/package/Tests.roc
@@ -30,6 +30,7 @@ interface Tests
             utf8ToInt,
             utf8ToIntSigned,
             validateUtf8SingleBytes,
+            ymdToDaysInYear,
         },
     ]
 
@@ -304,3 +305,8 @@ expect calendarWeekToDaysInYear 1 1971 == 3
 expect calendarWeekToDaysInYear 1 1972 == 2
 expect calendarWeekToDaysInYear 1 1973 == 0
 expect calendarWeekToDaysInYear 2 2024 == 7
+
+# <---- ymdToDaysInYear ---->
+expect ymdToDaysInYear 1970 1 1 == 1
+expect ymdToDaysInYear 1970 12 31 == 365
+expect ymdToDaysInYear 1972 3 1 == 61

--- a/package/Tests.roc
+++ b/package/Tests.roc
@@ -81,6 +81,8 @@ expect parseDateFromStr "2024-Ww1" == Err InvalidDateFormat
 # parseWeekDateBasic
 expect parseDateFromStr "2024W042" == (19_723 + 22) * secondsPerDay * nanosPerSecond |> Num.toI128 |> fromNanosSinceEpoch |> Ok
 expect parseDateFromStr "1970W011" == 0 |> Num.toI128 |> fromNanosSinceEpoch |> Ok
+expect parseDateFromStr "1970W524" == 364 * secondsPerDay * nanosPerSecond |> Num.toI128 |> fromNanosSinceEpoch |> Ok
+expect parseDateFromStr "1970W525" == parseDateFromStr "19710101"
 expect parseDateFromStr "1968W011" == -731 * secondsPerDay * nanosPerSecond |> Num.toI128 |> fromNanosSinceEpoch |> Ok
 expect parseDateFromStr "2024W001" == Err InvalidDateFormat
 expect parseDateFromStr "2024W531" == Err InvalidDateFormat

--- a/package/Time.roc
+++ b/package/Time.roc
@@ -22,11 +22,13 @@ Time : { hour : U8, minute : U8, second : U8, nanosecond : U32 }
 midnight : Time
 midnight = { hour: 0, minute: 0, second: 0, nanosecond: 0 }
 
-fromHms : U8, U8, U8 -> Time
-fromHms = \hour, minute, second -> { hour, minute, second, nanosecond: 0 }
+fromHms : Int *, Int *, Int * -> Time
+fromHms = \hour, minute, second -> { hour: Num.toU8 hour, minute: Num.toU8 minute, second: Num.toU8 second, nanosecond: 0u32 }
 
-fromHmsn : U8, U8, U8, U32 -> Time
-fromHmsn = \hour, minute, second, nanosecond -> { hour, minute, second, nanosecond }
+fromHmsn : Int *, Int *, Int *, Int * -> Time
+fromHmsn = \hour, minute, second, nanosecond -> 
+    { hour: Num.toU8 hour, minute: Num.toU8 minute, second: Num.toU8 second, nanosecond: Num.toU32 nanosecond }
+    #{ hour, minute, second, nanosecond }
 
 toUtcTime : Time -> UtcTime
 toUtcTime = \time ->

--- a/package/Time.roc
+++ b/package/Time.roc
@@ -1,0 +1,52 @@
+interface Time
+    exposes [
+        fromHms,
+        fromHmsn,
+        fromUtcTime,
+        midnight,
+        Time,
+        toUtcTime,
+    ]
+    imports [
+        Const,
+        UtcTime,
+        UtcTime.{
+            UtcTime,
+            fromNanosSinceMidnight,
+            toNanosSinceMidnight,
+        }
+    ]
+
+Time : { hour : U8, minute : U8, second : U8, nanosecond : U32 }
+
+midnight : Time
+midnight = { hour: 0, minute: 0, second: 0, nanosecond: 0 }
+
+fromHms : U8, U8, U8 -> Time
+fromHms = \hour, minute, second -> { hour, minute, second, nanosecond: 0 }
+
+fromHmsn : U8, U8, U8, U32 -> Time
+fromHmsn = \hour, minute, second, nanosecond -> { hour, minute, second, nanosecond }
+
+toUtcTime : Time -> UtcTime
+toUtcTime = \time ->
+    hNanos = time.hour |> Num.toI64 |> Num.mul Const.nanosPerHour |> Num.toI64
+    mNanos = time.minute |> Num.toI64 |> Num.mul Const.nanosPerMinute |> Num.toI64
+    sNanos = time.second |> Num.toI64 |> Num.mul Const.nanosPerSecond |> Num.toI64
+    nanos = time.nanosecond |> Num.toI64
+    fromNanosSinceMidnight (hNanos + mNanos + sNanos + nanos)
+
+expect
+    utc = toUtcTime (fromHms 12 34 56)
+    fromUtcTime utc == fromHms 12 34 56
+
+fromUtcTime : UtcTime -> Time
+fromUtcTime = \utcTime ->
+    nanos1 = toNanosSinceMidnight utcTime |> Num.toU64
+    hour = nanos1 // Const.nanosPerHour |> Num.toU8
+    nanos2 = nanos1 % Const.nanosPerHour
+    minute = nanos2 // Const.nanosPerMinute |> Num.toU8
+    nanos3 = nanos2 % Const.nanosPerMinute
+    second = nanos3 // Const.nanosPerSecond |> Num.toU8
+    nanosecond = nanos3 % Const.nanosPerSecond |> Num.toU32
+    { hour, minute, second, nanosecond }

--- a/package/Time.roc
+++ b/package/Time.roc
@@ -37,8 +37,8 @@ toUtcTime = \time ->
     fromNanosSinceMidnight (hNanos + mNanos + sNanos + nanos)
 
 expect
-    utc = toUtcTime (fromHms 12 34 56)
-    fromUtcTime utc == fromHms 12 34 56
+    utc = toUtcTime (fromHmsn 12 34 56 5)
+    utc == fromNanosSinceMidnight (12 * Const.nanosPerHour + 34 * Const.nanosPerMinute + 56 * Const.nanosPerSecond + 5)
 
 fromUtcTime : UtcTime -> Time
 fromUtcTime = \utcTime ->
@@ -50,3 +50,7 @@ fromUtcTime = \utcTime ->
     second = nanos3 // Const.nanosPerSecond |> Num.toU8
     nanosecond = nanos3 % Const.nanosPerSecond |> Num.toU32
     { hour, minute, second, nanosecond }
+
+expect
+    utcTime = toUtcTime { hour: 12, minute: 34, second: 56, nanosecond: 5 }
+    utcTime == fromNanosSinceMidnight (12 * Const.nanosPerHour + 34 * Const.nanosPerMinute + 56 * Const.nanosPerSecond + 5 )

--- a/package/Utils.roc
+++ b/package/Utils.roc
@@ -169,6 +169,7 @@ numDaysSinceEpoch = \{year, month? 1, day? 1} ->
             |> List.sum |> Num.add (daysInYears + (getMonthDays month) - day + 1) 
             |> Num.toI64 |> Num.mul -1
 
+# TODO: rename to numDaysSinceEpochUntilYear
 numDaysSinceEpochToYear = \year ->
     numDaysSinceEpoch {year, month: 1, day: 1}
 

--- a/package/Utils.roc
+++ b/package/Utils.roc
@@ -203,6 +203,3 @@ ymdToDaysInYear = \year, month, day ->
     |> List.sum
     |> Num.add (Num.toU64 day)
     |> Num.toU16
-
-expect ymdToDaysInYear 1970 1 1 == 1
-expect ymdToDaysInYear 1970 12 31 == 365

--- a/package/main.roc
+++ b/package/main.roc
@@ -1,6 +1,8 @@
 package "RocISODate"
     exposes [
+        Date,
         IsoToUtc,
+        Time,
         Utc,
         UtcTime,
     ]

--- a/package/main.roc
+++ b/package/main.roc
@@ -1,6 +1,7 @@
 package "RocISODate"
     exposes [
         Date,
+        DateTime,
         IsoToUtc,
         Time,
         Utc,


### PR DESCRIPTION
Each type includes various constructors, and can be converted to and from `Utc` / `UtcTime` types.

This work is done in preparation for supporting parsing to DateTime formats as well as the Utc format.