### PR TITLE
Refactor Date type to include month and dayOfMonth fields

### DIFF
--- a/package/Date.roc
+++ b/package/Date.roc
@@ -20,26 +20,43 @@ interface Date
         }
     ]
 
-Date : { year: I64, dayOfYear: U16 }
+Date : { year: I64, month: U8, dayOfMonth: U8, dayOfYear: U16 }
 
 unixEpoch : Date
-unixEpoch = { year: 1970, dayOfYear: 1 }
+unixEpoch = { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
 
 fromYd : Int *, Int * -> Date
-fromYd = \year, dayOfYear -> { year: Num.toI64 year, dayOfYear: Num.toU16 dayOfYear }
+fromYd = \year, dayOfYear -> 
+    ydToYmdd year dayOfYear
+
+ydToYmdd : Int *, Int * -> { year: I64, month: U8, dayOfMonth: U8, dayOfYear: U16 }
+ydToYmdd = \year, dayOfYear ->
+    List.range { start: At 1, end: At 12 }
+    |> List.map \m -> Const.monthDays { month: Num.toU64 m, isLeap: isLeapYear year }
+    |> List.walkUntil { daysRemaining: Num.toU16 dayOfYear, month: 1 } walkUntilMonthFunc
+    |> \result -> { year: Num.toI64 year, month: Num.toU8 result.month, dayOfMonth: Num.toU8 result.daysRemaining, dayOfYear: Num.toU16 dayOfYear }
+
+walkUntilMonthFunc : { daysRemaining: U16, month: U8 }, U64 -> [Break { daysRemaining: U16, month: U8 }, Continue { daysRemaining: U16, month: U8 }]
+walkUntilMonthFunc = \state, currMonthDays ->
+    if state.daysRemaining <= Num.toU16 currMonthDays then
+        Break { daysRemaining: state.daysRemaining, month: state.month }
+    else
+        Continue { daysRemaining: state.daysRemaining - Num.toU16 currMonthDays, month: state.month + 1 }
 
 fromYmd : Int *, Int *, Int * -> Date
 fromYmd =\year, month, day -> 
-    { year: Num.toI64 year, dayOfYear: ymdToDaysInYear year month day }
+    { year: Num.toI64 year, month: Num.toU8 month, dayOfMonth: Num.toU8 day, dayOfYear: ymdToDaysInYear year month day }
 
 fromYwd : Int *, Int *, Int * -> Date
 fromYwd = \year, week, day ->
     daysInYear = if isLeapYear year then 366 else 365
     d = calendarWeekToDaysInYear week year |> Num.add (Num.toU64 day)
     if d > daysInYear then
-        { year: Num.toI64 (year + 1), dayOfYear: Num.toU16 (d - daysInYear) }
+        ydToYmdd (year + 1) (d - daysInYear)
+        #{ year: Num.toI64 (year + 1), dayOfYear: Num.toU16 (d - daysInYear) }
     else
-        { year: Num.toI64 year, dayOfYear: Num.toU16 d }
+        ydToYmdd year d
+        #{ year: Num.toI64 year, dayOfYear: Num.toU16 d }
 
 fromYw : Int *, Int * -> Date
 fromYw = \year, week ->
@@ -60,7 +77,8 @@ fromUtcHelper =\days, year ->
         if days >= daysInYear then
             fromUtcHelper (days - daysInYear) (year + 1)
         else
-            { year: year, dayOfYear: days + 1 |> Num.toU16 }
+            ydToYmdd year (days + 1)
+            #{ year: year, dayOfYear: days + 1 |> Num.toU16 }
 
 toUtc : Date -> Utc.Utc
 toUtc =\date ->
@@ -69,69 +87,76 @@ toUtc =\date ->
 
 
 # <==== TESTS ====>
+# <---- ydToYmdd ---->
+expect ydToYmdd 1970 1 == { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
+expect ydToYmdd 1970 31 == { year: 1970, month: 1, dayOfMonth: 31, dayOfYear: 31 }
+expect ydToYmdd 1970 32 == { year: 1970, month: 2, dayOfMonth: 1, dayOfYear: 32 }
+expect ydToYmdd 1970 60 == { year: 1970, month: 3, dayOfMonth: 1, dayOfYear: 60 }
+expect ydToYmdd 1972 61 == { year: 1972, month: 3, dayOfMonth: 1, dayOfYear: 61 }
+
 # <---- fromYmd ---->
-expect fromYmd 1970 1 1 == { year: 1970, dayOfYear: 1 }
-expect fromYmd 1970 12 31 == { year: 1970, dayOfYear: 365 }
-expect fromYmd 1972 3 1 == { year: 1972, dayOfYear: 61 }
+expect fromYmd 1970 1 1 == { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
+expect fromYmd 1970 12 31 == { year: 1970, month: 12, dayOfMonth: 31,  dayOfYear: 365 }
+expect fromYmd 1972 3 1 == { year: 1972, month: 3, dayOfMonth: 1, dayOfYear: 61 }
 
 # <---- fromYwd ---->
-expect fromYwd 1970 1 1 == { year: 1970, dayOfYear: 1 }
-expect fromYwd 1970 52 5 == { year: 1971, dayOfYear: 1 }
+expect fromYwd 1970 1 1 == { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
+expect fromYwd 1970 52 5 == { year: 1971, month: 1, dayOfMonth: 1, dayOfYear: 1 }
 
 # <---- fromYw ---->
-expect fromYw 1970 1 == { year: 1970, dayOfYear: 1 }
-expect fromYw 1971 1 == { year: 1971, dayOfYear: 4 }
+expect fromYw 1970 1 == { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
+expect fromYw 1971 1 == { year: 1971, month: 1, dayOfMonth: 4, dayOfYear: 4 }
 
 # <---- fromUtc ---->
 expect
     utc = Utc.fromNanosSinceEpoch 0
-    fromUtc utc == { year: 1970, dayOfYear: 1 }
+    fromUtc utc == { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
 
 expect
     utc = Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * 365)
-    fromUtc utc == { year: 1971, dayOfYear: 1 }
+    fromUtc utc == { year: 1971, month: 1, dayOfMonth: 1, dayOfYear: 1 }
 
 expect
     utc = Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * 365 * 2 + Const.nanosPerHour * 24 * 366)
-    fromUtc utc == { year: 1973, dayOfYear: 1 }
+    fromUtc utc == { year: 1973, month: 1, dayOfMonth: 1, dayOfYear: 1 }
 
 expect
     utc = Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * -1)
-    fromUtc utc == { year: 1969, dayOfYear: 365 }
+    fromUtc utc == { year: 1969, month: 12, dayOfMonth: 31, dayOfYear: 365 }
 
 expect
     utc = Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * -365)
-    fromUtc utc == { year: 1969, dayOfYear: 1 }
+    fromUtc utc == { year: 1969, month: 1, dayOfMonth: 1, dayOfYear: 1 }
 
 expect
     utc = Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * -365 - Const.nanosPerHour * 24 * 366)
-    fromUtc utc == { year: 1968, dayOfYear: 1 }
+    fromUtc utc == { year: 1968, month: 1, dayOfMonth: 1, dayOfYear: 1 }
 
 expect
     utc = Utc.fromNanosSinceEpoch -1
-    fromUtc utc == { year: 1969, dayOfYear: 365 }
+    fromUtc utc == { year: 1969, month: 12, dayOfMonth: 31, dayOfYear: 365 }
 
 # <---- toUtc ---->
 expect 
-    utc = toUtc { year: 1970, dayOfYear: 1 } 
+    utc = toUtc { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 } 
     utc == Utc.fromNanosSinceEpoch 0
 
 expect 
-    utc = toUtc { year: 1970, dayOfYear: 365 }
+    utc = toUtc { year: 1970, month: 12, dayOfMonth: 31, dayOfYear: 365 }
     utc == Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * 364)
 
 expect
-    utc = toUtc { year: 1973, dayOfYear: 1 }
+    utc = toUtc { year: 1973, month: 1, dayOfMonth: 1, dayOfYear: 1 }
     utc == Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * 365 * 2 + Const.nanosPerHour * 24 * 366)
 
 expect
-    utc = toUtc { year: 1969, dayOfYear: 365 }
+    utc = toUtc { year: 1969, month: 12, dayOfMonth: 31, dayOfYear: 365 }
     utc == Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * -1)
 
 expect
-    utc = toUtc { year: 1969, dayOfYear: 1 }
+    utc = toUtc { year: 1969, month: 1, dayOfMonth: 1, dayOfYear: 1 }
     utc == Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * -365)
 
 expect
-    utc = toUtc { year: 1968, dayOfYear: 1 }
+    utc = toUtc { year: 1968, month: 1, dayOfMonth: 1, dayOfYear: 1 }
     utc == Utc.fromNanosSinceEpoch (Const.nanosPerHour * 24 * -365 - Const.nanosPerHour * 24 * 366)

--- a/package/Utils.roc
+++ b/package/Utils.roc
@@ -174,7 +174,7 @@ numDaysSinceEpochToYear = \year ->
     numDaysSinceEpoch {year, month: 1, day: 1}
 
 daysToNanos = \days ->
-    days * secondsPerDay * nanosPerSecond |> Num.toI128
+    days * secondsPerDay * nanosPerSecond |> Num.toI128    
 
 timeToNanos : {hour: I64, minute: I64, second: I64} -> I64
 timeToNanos = \{hour, minute, second} ->


### PR DESCRIPTION
Expanded the definition of the Date type to include additional fields which may be commonly wanted by the user.

The type signature of `Date` has been changed as follows:
```Roc
# Old date type:
Date: { year: I64, dayOfYear: U16 }

# Updated date type:
Date: { year: I64, month: U8, dayOfMonth: U8, dayOfYear: U16 }
```