### PR TITLE
Remove <- backpassing and upgrade to basic-cli 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,33 +39,29 @@ To extend functionality and simplify the API, library _now_ simply provides a co
 Thus, an application might look like the following:
 
 ```roc
-app "MyDateApp"
-    packages {
-        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
-        dt: "https://github.com/imclerran/Roc-IsoDate/releases/download/v0.3.0/GLLnv2LpABZzVYHlata79rpfaF_bJaxsbYMLtk-mF_w.tar.br",
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
+    dt: "./main.roc",
+}
 
-    }
-    imports [
-        dt.DateTime,
-        dt.Duration,
-        pf.Utc,
-        pf.Stdout,
-        pf.Task,
-    ]
-    provides [main] to pf
+import dt.DateTime
+import dt.Duration
+import pf.Utc
+import pf.Stdout
+import pf.Task exposing [Task]
 
 main =
     utcNow = Utc.now!
-    dtNow = Utc.toNanosSinceEpoch utcNow |> DateTime.fromNanosSinceEpoch # Convert Utc to DateTime easily
+    dtNow = utcNow |> Utc.toNanosSinceEpoch |> DateTime.fromNanosSinceEpoch # Convert Utc to DateTime easily
     dtEpoch = DateTime.unixEpoch # Constructor for the epoch
-    dtSomeTime = DateTime.fromIsoStr "2024-04-19T11:31:41.329515-05:00" # parse a DateTime from ISO str easily
-    dtLaterDate = dtSomeTime |> DateTime.addDateTimeAndDuration (Duration.fromHours 25 |> unwrap "25 hours should not overflow") # Add a duration to a DateTime easily
-    utcLaterDate = DateTime.toNanosSinceEpoch dtSomeTime |> Utc.fromNanosSinceEpoch # Convert parsed date to Utc
+    dtSomeTime = DateTime.fromIsoStr "2024-04-19T11:31:41.329515-05:00" |> unwrap "This is a valid datetime" # parse a DateTime from ISO str easily
+    dtLaterDate = dtSomeTime |> DateTime.addDateTimeAndDuration (Duration.fromHours 25 |> unwrap "25 hours cannot overflow") # Add a duration to a DateTime easily
+    utcLaterDate = DateTime.toNanosSinceEpoch dtLaterDate |> Utc.fromNanosSinceEpoch # Convert parsed date to Utc
     nanosLaterDate = Utc.toNanosSinceEpoch utcLaterDate
 
     Stdout.line! "ISO epoch: $(DateTime.toIsoStr dtEpoch)"
     Stdout.line! "Time now: $(Num.toStr dtNow.time.hour):$(Num.toStr dtNow.time.minute):$(Num.toStr dtNow.time.second)"
-    Stdout.line! "Day some time: $(Num.toStr dtSomeTime.date.day)"
+    Stdout.line! "Day some time: $(Num.toStr dtSomeTime.date.dayOfMonth)"
     Stdout.line! "Utc nanos later date: $(Num.toStr nanosLaterDate)"
 
 unwrap : Result a _, Str -> a

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Thus, an application might look like the following:
 ```roc
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
-    dt: "./main.roc",
+    dt: "https://github.com/imclerran/roc-isodate/releases/download/v0.4.1/OQwyjDUYQkmGRiaISkzBcw5dpnbi1OHi8KUDl7NZmC8.tar.br",
 }
 
 import dt.DateTime

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@
 Roc-IsoDate is a universal date and time package for Roc. It Features several useful types for working with dates and times. Its primary types (`Date`/`Time`/`DateTime`) store dates and times in a human friendly manner, but allow easy conversion to and from computer friendly types like `Utc` as well as web web friendly ISO 8601 strings. Roc IsoDate is intended to be a one-stop-shop for all things date and time. 📆 ⏰ 📦
 
 ## Implementation
+
 Roc IsoDate's API revolves around its types, primarily `Date`, `Time`, and `DateTime`. These types provide useful functions for such as `fromIsoStr`, `fromIsoStr`, as well as functions for parsing directly from a list of Utf8 bytes. The types are based on records containing some of the most common data fields a user might want for working with dates and times in a human friendly manner, IE: `year`, `month`, `dayOfMonth`, `dayOfYear`, `hour`, `minute`, `second` and `nanosecond`. It also provides functions for performing math operations on these dates, as well as various constructors, and functions to convert to and from nanoseconds since the epoch for dates or since midnght for time.
 
 Note that due to the expense of purchasing the ISO 8601-2:2019 standard document, my implementation of ISO string parsing is based on a [2016 pre-release][iso_8601_doc] copy of the 8601-1 standard, so my implementation may not fully conform to the latest revision to the standard.
 
 ## Progress
+
 - Full support for parsing all date representations.
 - Full support for parseing local time representations.
 - Full support for offset from UTC time representations.
@@ -21,22 +23,25 @@ Note that due to the expense of purchasing the ISO 8601-2:2019 standard document
   - This means converting to and from ISO strings is as simple as:
   - `DateTime.fromIsoStr str` or `Time.toIsoStr date`
   - Similarly, converting to and from `Utc` is easy:
-  - `Date.toNanosSinceEpoch date |> Utc.fromNanosSinceEpoch` or 
+  - `Date.toNanosSinceEpoch date |> Utc.fromNanosSinceEpoch` or
     `DateTime.toNanosSinceEpoch utc |> Utc.fromNanosSinceEpoch`
 
 ## Future Plans
+
 - Time interval representations will be added once the parsing to Date/Time/DateTime is complete [DONE 🚀].
 - Once Parsing is complete, add formatting dates and times to ISO strings.
 - Research adding custom encoding/decoding for json parsers.
 
 ## Unified API
-To extend functionality and simplify the API, library *now* simply provides a collection of types for working with dates. Each of these types provide all the necessary functions for interacting with it, including functions for converting to and from ISO strings, and converting to and from Utc types, as well as various other constructors and math functions.
+
+To extend functionality and simplify the API, library _now_ simply provides a collection of types for working with dates. Each of these types provide all the necessary functions for interacting with it, including functions for converting to and from ISO strings, and converting to and from Utc types, as well as various other constructors and math functions.
 
 Thus, an application might look like the following:
+
 ```roc
 app "MyDateApp"
     packages {
-        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.9.0/oKWkaruh2zXxin_xfsYsCJobH1tO8_JvNkFzDwwzNUQ.tar.br",
+        pf: "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
         dt: "https://github.com/imclerran/Roc-IsoDate/releases/download/v0.3.0/GLLnv2LpABZzVYHlata79rpfaF_bJaxsbYMLtk-mF_w.tar.br",
 
     }
@@ -50,18 +55,18 @@ app "MyDateApp"
     provides [main] to pf
 
 main =
-    utcNow <- Task.await Utc.now
+    utcNow = Utc.now!
     dtNow = Utc.toNanosSinceEpoch utcNow |> DateTime.fromNanosSinceEpoch # Convert Utc to DateTime easily
     dtEpoch = DateTime.unixEpoch # Constructor for the epoch
     dtSomeTime = DateTime.fromIsoStr "2024-04-19T11:31:41.329515-05:00" # parse a DateTime from ISO str easily
     dtLaterDate = dtSomeTime |> DateTime.addDateTimeAndDuration (Duration.fromHours 25 |> unwrap "25 hours should not overflow") # Add a duration to a DateTime easily
     utcLaterDate = DateTime.toNanosSinceEpoch dtSomeTime |> Utc.fromNanosSinceEpoch # Convert parsed date to Utc
     nanosLaterDate = Utc.toNanosSinceEpoch utcLaterDate
-    
-    _ <- Stdout.line "ISO epoch: $(DateTime.toIsoStr dtEpoch)" |> Task.await
-    _ <- Stdout.line "Time now: $(Num.toStr dtNow.time.hour):$(Num.toStr dtNow.time.minute):$(Num.toStr dtNow.time.second)" |> Task.await
-    _ <- Stdout.line "Day some time: $(Num.toStr dtSomeTime.date.day)" |> Task.await
-    Stdout.line "Utc nanos later date: $(Num.toStr nanosLaterDate)"
+
+    Stdout.line! "ISO epoch: $(DateTime.toIsoStr dtEpoch)"
+    Stdout.line! "Time now: $(Num.toStr dtNow.time.hour):$(Num.toStr dtNow.time.minute):$(Num.toStr dtNow.time.second)"
+    Stdout.line! "Day some time: $(Num.toStr dtSomeTime.date.day)"
+    Stdout.line! "Utc nanos later date: $(Num.toStr nanosLaterDate)"
 
 unwrap : Result a _, Str -> a
 unwrap = \x, message ->
@@ -73,13 +78,14 @@ unwrap = \x, message ->
 This is just a small sample of the available functionality, but meant to demonstrate the general design of the API. Moving to and from computer-friendly representations like `Utc`, web-friendly representations like ISO `Str`s, and human friendly representations like `DateTime` are all just a single function call away. `Durations` and `TimeInterval`s also add quality of life functionality for easily manipulating dates and times.
 
 ## Known Issues
+
 - Missing features mentioned above.
 - ISO Requirement for combined date-time strings to have only non-reduced accuracy dates is not enforced
 - ISO Requirement for combined date-time strings to be in completely basic or completely extended format are not enforced.
 
 ## ISO 8601 Date/Time Format
-Description of ISO date/time [format][iso_8601_md] (WIP)
 
+Description of ISO date/time [format][iso_8601_md] (WIP)
 
 [roc_badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fpastebin.com%2Fraw%2FcFzuCCd7
 [roc_link]: https://github.com/roc-lang/roc
@@ -87,7 +93,6 @@ Description of ISO date/time [format][iso_8601_md] (WIP)
 [ci_status_link]: https://github.com/imclerran/Roc-IsoDate/actions/workflows/ci.yml
 [last_commit_badge]: https://img.shields.io/github/last-commit/imclerran/roc-isodate?logo=git&logoColor=lightgrey
 [last_commit_link]: https://github.com/imclerran/Roc-IsoDate/commits/main/
-
 [iso_8601_doc]: https://www.loc.gov/standards/datetime/iso-tc154-wg5_n0038_iso_wd_8601-1_2016-02-16.pdf
 [utc_link]: https://github.com/roc-lang/basic-cli/blob/main/platform/Utc.roc
 [utctime_link]: https://github.com/imlerran/roc-isodate/blob/main/platform/UtcTime.roc

--- a/examples/iso-to-datetime.roc
+++ b/examples/iso-to-datetime.roc
@@ -1,5 +1,5 @@
 app [main] {
-    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
     dt: "../package/main.roc",
 }
 

--- a/examples/utc-to-datetime.roc
+++ b/examples/utc-to-datetime.roc
@@ -1,5 +1,5 @@
 app [main] {
-    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
     dt: "../package/main.roc",
 }
 

--- a/package/Duration.roc
+++ b/package/Duration.roc
@@ -14,6 +14,7 @@ module [
 ]
 
 import Const
+import Unsafe exposing [unwrap] # for unit testing only
 
 Duration : { days : I64, hours : I8, minutes : I8, seconds : I8, nanoseconds : I32 }
 
@@ -138,27 +139,23 @@ addDurations = \d1, d2 ->
     fromNanoseconds (nanos1 + nanos2)
 
 expect
-    import Unsafe exposing [unwrap]
     days = Num.maxI64
     duration = fromDays days |> unwrap "will not overflow"
     duration |> toDays == days
 
 expect
-    import Unsafe exposing [unwrap]
     d1 = fromDays (Num.maxI64 // 2) |> unwrap "will not overflow"
     d2 = fromDays (Num.maxI64 // 2) |> unwrap "will not overflow"
     d3 = fromDays ((Num.maxI64 // 2) * 2) |> unwrap "will not overflow"
     addDurations d1 d2 == Ok d3
 
 expect
-    import Unsafe exposing [unwrap]
     d1 = fromDays Num.minI64 |> unwrap "will not overflow"
     d2 = fromDays Num.maxI64 |> unwrap "will not overflow"
     d3 = fromDays -1 |> unwrap "will not overflow"
     addDurations d1 d2 == Ok d3
 
 expect
-    import Unsafe exposing [unwrap]
     duration = fromDays Num.maxI64 |> unwrap "will not overflow"
     addDurations duration duration == Err DurationOverflow
 

--- a/package/Tests.roc
+++ b/package/Tests.roc
@@ -18,7 +18,7 @@ import Utils exposing [
     utf8ToIntSigned,
     validateUtf8SingleBytes,
 ]
-import Unsafe exposing [unwrap]
+import Unsafe exposing [unwrap] # for unit testing only
 
 # <==== Date.roc ====>
 # <---- parseDate ---->

--- a/package/Time.roc
+++ b/package/Time.roc
@@ -34,6 +34,7 @@ import Utils exposing [
     utf8ToIntSigned,
     validateUtf8SingleBytes,
 ]
+import Unsafe exposing [unwrap] # for unit testing only
 
 Time : { hour : I8, minute : U8, second : U8, nanosecond : U32 }
 
@@ -188,23 +189,23 @@ parseFractionalTime = \wholeBytes, fractionalBytes ->
             Err _ -> Err InvalidTimeFormat
     when (wholeBytes, utf8ToFrac fractionalBytes) is
         ([_, _], Ok frac) -> # hh
-            time <- parseLocalTimeHour wholeBytes |> Result.try
+            time = parseLocalTimeHour? wholeBytes
             frac * Const.nanosPerHour |> Num.round |> Duration.fromNanoseconds |> combineDurationResAndTime time
 
         ([_, _, _, _], Ok frac) -> # hhmm
-            time <- parseLocalTimeMinuteBasic wholeBytes |> Result.try
+            time = parseLocalTimeMinuteBasic? wholeBytes
             frac * Const.nanosPerMinute |> Num.round |> Duration.fromNanoseconds |> combineDurationResAndTime time
 
         ([_, _, ':', _, _], Ok frac) -> # hh:mm
-            time <- parseLocalTimeMinuteExtended wholeBytes |> Result.try
+            time = parseLocalTimeMinuteExtended? wholeBytes
             frac * Const.nanosPerMinute |> Num.round |> Duration.fromNanoseconds |> combineDurationResAndTime time
 
         ([_, _, _, _, _, _], Ok frac) -> # hhmmss
-            time <- parseLocalTimeBasic wholeBytes |> Result.try
+            time = parseLocalTimeBasic? wholeBytes
             frac * Const.nanosPerSecond |> Num.round |> Duration.fromNanoseconds |> combineDurationResAndTime time
 
         ([_, _, ':', _, _, ':', _, _], Ok frac) -> # hh:mm:ss
-            time <- parseLocalTimeExtended wholeBytes |> Result.try
+            time = parseLocalTimeExtended? wholeBytes
             frac * Const.nanosPerSecond |> Num.round |> Duration.fromNanoseconds |> combineDurationResAndTime time
 
         _ -> Err InvalidTimeFormat
@@ -333,7 +334,6 @@ expect addHours (fromHms 12 34 56) 12 == fromHms 24 34 56
 
 # <---- addTimeAndDuration ---->
 expect
-    import Unsafe exposing [unwrap] # for unit testing only
     addTimeAndDuration (fromHms 0 0 0) (Duration.fromHours 1 |> unwrap "will not overflow") == fromHms 1 0 0
 
 # <---- fromNanosSinceMidnight ---->

--- a/package/Utils.roc
+++ b/package/Utils.roc
@@ -88,26 +88,26 @@ utf8ToFrac = \u8List ->
                         (_, _) -> Err InvalidBytes
 
                 [['.'], tail] -> # if byte == ',' || byte == '.' -> # crashes when using byte comparison
-                    fracPart <- utf8ToInt tail |> Result.map
+                    fracPart = utf8ToInt? tail
                     decimalShift = List.len tail |> Num.toU8
-                    moveDecimalPoint (Num.toF64 fracPart) decimalShift
+                    Ok (moveDecimalPoint (Num.toF64 fracPart) decimalShift)
 
                 [[','], tail] -> # if byte == ',' || byte == '.' -> # crashes when using byte comparison
-                    fracPart <- utf8ToInt tail |> Result.map
+                    fracPart = utf8ToInt? tail
                     decimalShift = List.len tail |> Num.toU8
-                    moveDecimalPoint (Num.toF64 fracPart) decimalShift
+                    Ok (moveDecimalPoint (Num.toF64 fracPart) decimalShift)
 
                 [head, [byte]] if byte == ',' || byte == '.' ->
-                    intPart <- utf8ToInt head |> Result.map
-                    Num.toF64 intPart
+                    intPart = utf8ToInt? head
+                    Ok (Num.toF64 intPart)
 
                 _ ->
-                    intPart <- utf8ToInt u8List |> Result.map
-                    Num.toF64 intPart
+                    intPart = utf8ToInt? u8List
+                    Ok (Num.toF64 intPart)
 
         Err NoDecimalPoint ->
-            intPart <- utf8ToInt u8List |> Result.map
-            Num.toF64 intPart
+            intPart = utf8ToInt? u8List
+            Ok (Num.toF64 intPart)
 
 findDecimalIndex : List U8 -> Result U8 [NoDecimalPoint]
 findDecimalIndex = \u8List ->


### PR DESCRIPTION
Thanks for this library!

This PR removes `<-` backpassing (which causes deprecation warnings) and upgrades to the latest basic-cli 0.14.0.

It also runs `roc format` on every `.roc` file and works around a couple compiler bugs:
* some `if ... then` statements caused the latest compiler to crash, so I reformatted them (e.g., adding parentheses)
* the use of `import Unsafe exposing [unwrap]` in an `expect` statement caused the compiler to crash, so I moved the import to the beginning of the file.

Hope this helps.