### PR TITLE
Migrate package identifiers to snake_case

### DIFF
--- a/examples/iso-to-datetime.roc
+++ b/examples/iso-to-datetime.roc
@@ -1,5 +1,5 @@
 app [main] {
-    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.17.0/lZFLstMUCUvd5bjnnpYromZJXkQUrdhbva4xdBInicE.tar.br",
     dt: "../package/main.roc",
 }
 
@@ -7,26 +7,26 @@ import pf.Http
 import pf.Stdout
 import dt.DateTime
 
-main =
-    response = Http.send! (formatRequest "America/Chicago")
-    responseBody =
+main = 
+    response = Http.send! (format_request "America/Chicago")
+    response_body =
         when response |> Http.handleStringResponse is
             Err err -> crash (Http.errorToString err)
             Ok body -> body
 
-    isoStr = getIsoString responseBody
+    iso_str = get_iso_string response_body
 
-    dtNow =
-        when DateTime.fromIsoStr isoStr is
-            Ok dateTime -> dateTime
+    dt_now =
+        when DateTime.from_iso_str iso_str is
+            Ok date_time -> date_time
             Err _ -> crash "Parsing Error"
 
-    timeStr = "$(Num.toStr dtNow.time.hour):$(Num.toStr dtNow.time.minute):$(Num.toStr dtNow.time.second)"
-    dateStr = "$(Num.toStr dtNow.date.year)-$(Num.toStr dtNow.date.month)-$(Num.toStr dtNow.date.dayOfMonth)"
-    Stdout.line! "The current Zulut date is: $(dateStr)"
-    Stdout.line "The current Zulu time is: $(timeStr)"
+    time_str = "$(Num.toStr dt_now.time.hour):$(Num.toStr dt_now.time.minute):$(Num.toStr dt_now.time.second)"
+    date_str = "$(Num.toStr dt_now.date.year)-$(Num.toStr dt_now.date.month)-$(Num.toStr dt_now.date.day_of_month)"
+    Stdout.line! "The current Zulut date is: $(date_str)"
+    Stdout.line! "The current Zulu time is: $(time_str)"
 
-formatRequest = \timezone -> {
+format_request = \timezone -> {
     method: Get,
     headers: [],
     url: "http://worldtimeapi.org/api/timezone/$(timezone).txt",
@@ -35,11 +35,11 @@ formatRequest = \timezone -> {
     timeout: TimeoutMilliseconds 5000,
 }
 
-getIsoString = \body ->
-    when Str.splitOn body "\n" |> List.get 2 is
+get_iso_string = \body ->
+    when Str.splitOn body "\n" |> List.get 3 is
         Ok line ->
             when Str.splitFirst line ":" is
-                Ok lineParts -> lineParts.after |> Str.trim
+                Ok line_parts -> line_parts.after |> Str.trim
                 Err _ -> crash "Error splitting line at delimiter"
 
         Err _ -> crash "Error getting output line"

--- a/examples/utc-to-datetime.roc
+++ b/examples/utc-to-datetime.roc
@@ -1,18 +1,17 @@
 app [main] {
-    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.17.0/lZFLstMUCUvd5bjnnpYromZJXkQUrdhbva4xdBInicE.tar.br",
     dt: "../package/main.roc",
 }
 
 import pf.Stdout
-import pf.Task
 import pf.Utc
 import dt.DateTime
 
 main =
-    utcNow = Utc.now!
-    nowStr =
-        utcNow
+    utc_now = Utc.now! {}
+    now_str =
+        utc_now
         |> Utc.toNanosSinceEpoch
-        |> DateTime.fromNanosSinceEpoch
-        |> DateTime.toIsoStr
-    Stdout.line "Hello, World! The current Zulu time is: $(nowStr)"
+        |> DateTime.from_nanos_since_epoch
+        |> DateTime.to_iso_str
+    Stdout.line! "Hello, World! The current Zulu time is: $(now_str)"

--- a/package/Const.roc
+++ b/package/Const.roc
@@ -1,65 +1,65 @@
 module [
-    daysPerLeapYear,
-    daysPerNonLeapYear,
-    daysPerWeek,
-    epochDay,
-    epochMonth,
-    epochWeekOffset,
-    epochYear,
-    hoursPerDay,
-    leapException,
-    leapInterval,
-    leapNonException,
-    minutesPerDay,
-    minutesPerHour,
-    monthDays,
-    nanosPerDay,
-    nanosPerHour,
-    nanosPerMilli,
-    nanosPerMinute,
-    nanosPerSecond,
-    nanosPerSecond,
-    secondsPerDay,
-    secondsPerHour,
-    secondsPerMinute,
-    weeksPerYear,
+    days_per_leap_year,
+    days_per_non_leap_year,
+    days_per_week,
+    epoch_day,
+    epoch_month,
+    epoch_week_offset,
+    epoch_year,
+    hours_per_day,
+    leap_exception,
+    leap_interval,
+    leap_non_exception,
+    minutes_per_day,
+    minutes_per_hour,
+    month_days,
+    nanos_per_day,
+    nanos_per_hour,
+    nanos_per_milli,
+    nanos_per_minute,
+    nanos_per_second,
+    nanos_per_second,
+    seconds_per_day,
+    seconds_per_hour,
+    seconds_per_minute,
+    weeks_per_year,
 ]
 
-epochYear = 1970
-epochMonth = 1
-epochDay = 1
-epochWeekOffset = 4
+epoch_year = 1970
+epoch_month = 1
+epoch_day = 1
+epoch_week_offset = 4
 
-hoursPerDay = 24
+hours_per_day = 24
 
-minutesPerHour = 60
-minutesPerDay = hoursPerDay * minutesPerHour
+minutes_per_hour = 60
+minutes_per_day = hours_per_day * minutes_per_hour
 
-nanosPerMilli = 1_000_000
-nanosPerSecond = 1_000_000_000
-nanosPerMinute = 60 * nanosPerSecond
-nanosPerHour = 60 * nanosPerMinute
-nanosPerDay = 24 * nanosPerHour
+nanos_per_milli = 1_000_000
+nanos_per_second = 1_000_000_000
+nanos_per_minute = 60 * nanos_per_second
+nanos_per_hour = 60 * nanos_per_minute
+nanos_per_day = 24 * nanos_per_hour
 
-secondsPerMinute = 60
-secondsPerHour = 3600
-secondsPerDay = 86_400
+seconds_per_minute = 60
+seconds_per_hour = 3600
+seconds_per_day = 86_400
 
-leapInterval = 4
-leapException = 100
-leapNonException = 400
+leap_interval = 4
+leap_exception = 100
+leap_non_exception = 400
 
-daysPerNonLeapYear = 365
-daysPerLeapYear = 366
+days_per_non_leap_year = 365
+days_per_leap_year = 366
 
-daysPerWeek = 7
-weeksPerYear = 52
+days_per_week = 7
+weeks_per_year = 52
 
-monthDays : { month : Int *, isLeap ? Bool } -> U64
-monthDays = \{ month, isLeap ? Bool.false } ->
+month_days : { month : Int *, is_leap ? Bool } -> U64
+month_days = \{ month, is_leap ? Bool.false } ->
     when month is
         1 | 3 | 5 | 7 | 8 | 10 | 12 -> 31
         4 | 6 | 9 | 11 -> 30
-        2 if isLeap -> 29
+        2 if is_leap -> 29
         2 -> 28
         _ -> 0

--- a/package/ContextualDuration.roc
+++ b/package/ContextualDuration.roc
@@ -1,35 +1,24 @@
 module [
-    fromHms,
-    fromHmsn,
-    fromYmd,
-    fromYmdHms,
-    fromYmdHmsn,
+    from_hms,
+    from_hmsn,
+    from_ymd,
+    from_ymd_hms,
+    from_ymd_hmsn,
 ]
 
 ContextualDuration : { years : I64, months : I8, days : I16, hours : I8, minutes : I8, seconds : I8, nanoseconds : I32 }
 
-fromYmd : Int *, Int *, Int * -> ContextualDuration
-fromYmd = \y, m, d -> { years: Num.toI64 y, months: Num.toI8 m, days: Num.toI16 d, hours: 0, minutes: 0, seconds: 0, nanoseconds: 0 }
+from_ymd : Int *, Int *, Int * -> ContextualDuration
+from_ymd = \y, m, d -> { years: Num.toI64 y, months: Num.toI8 m, days: Num.toI16 d, hours: 0, minutes: 0, seconds: 0, nanoseconds: 0 }
 
-fromHms : Int *, Int *, Int * -> ContextualDuration
-fromHms = \h, m, s -> { years: 0, months: 0, days: 0, hours: Num.toI8 h, minutes: Num.toI8 m, seconds: Num.toI8 s, nanoseconds: 0 }
+from_hms : Int *, Int *, Int * -> ContextualDuration
+from_hms = \h, m, s -> { years: 0, months: 0, days: 0, hours: Num.toI8 h, minutes: Num.toI8 m, seconds: Num.toI8 s, nanoseconds: 0 }
 
-fromHmsn : Int *, Int *, Int *, Int * -> ContextualDuration
-fromHmsn = \h, m, s, n -> { years: 0, months: 0, days: 0, hours: Num.toI8 h, minutes: Num.toI8 m, seconds: Num.toI8 s, nanoseconds: Num.toI32 n }
+from_hmsn : Int *, Int *, Int *, Int * -> ContextualDuration
+from_hmsn = \h, m, s, n -> { years: 0, months: 0, days: 0, hours: Num.toI8 h, minutes: Num.toI8 m, seconds: Num.toI8 s, nanoseconds: Num.toI32 n }
 
-fromYmdHms : Int *, Int *, Int *, Int *, Int *, Int * -> ContextualDuration
-fromYmdHms = \y, m, d, h, mi, s -> { years: Num.toI64 y, months: Num.toI8 m, days: Num.toI16 d, hours: Num.toI8 h, minutes: Num.toI8 mi, seconds: Num.toI8 s, nanoseconds: 0 }
+from_ymd_hms : Int *, Int *, Int *, Int *, Int *, Int * -> ContextualDuration
+from_ymd_hms = \y, m, d, h, mi, s -> { years: Num.toI64 y, months: Num.toI8 m, days: Num.toI16 d, hours: Num.toI8 h, minutes: Num.toI8 mi, seconds: Num.toI8 s, nanoseconds: 0 }
 
-fromYmdHmsn : Int *, Int *, Int *, Int *, Int *, Int *, Int * -> ContextualDuration
-fromYmdHmsn = \y, m, d, h, mi, s, n -> { years: Num.toI64 y, months: Num.toI8 m, days: Num.toI16 d, hours: Num.toI8 h, minutes: Num.toI8 mi, seconds: Num.toI8 s, nanoseconds: Num.toI32 n }
-
-# TODO: functions below belong in Date
-
-# addDateAndDuration : Date, ContextualDuration -> Date
-# addDateAndDuration = \date, duration ->
-#     Date.addYears date duration.years
-#     |> Date.addMonths duration.months
-#     |> Date.addDays duration.days
-
-# addDurationAndDate : ContextualDuration, Date -> Date
-# addDurationAndDate = \duration, date -> addDateAndDuration date duration
+from_ymd_hmsn : Int *, Int *, Int *, Int *, Int *, Int *, Int * -> ContextualDuration
+from_ymd_hmsn = \y, m, d, h, mi, s, n -> { years: Num.toI64 y, months: Num.toI8 m, days: Num.toI16 d, hours: Num.toI8 h, minutes: Num.toI8 mi, seconds: Num.toI8 s, nanoseconds: Num.toI32 n }

--- a/package/Date.roc
+++ b/package/Date.roc
@@ -2,405 +2,405 @@
 ##
 ## These functions include functions for creating dates from varioius numeric values, converting dates to and from ISO 8601 strings, and performing arithmetic operations on dates.
 module [
-    addDateAndDuration,
-    addDays,
-    addDurationAndDate,
-    addMonths,
-    addYears,
+    add_date_and_duration,
+    add_days,
+    add_duration_and_date,
+    add_months,
+    add_years,
     Date,
-    daysInMonth,
-    fromIsoStr,
-    fromIsoU8,
-    fromNanosSinceEpoch,
-    fromYd,
-    fromYmd,
-    fromYw,
-    fromYwd,
-    isLeapYear,
-    toIsoStr,
-    toIsoU8,
-    toNanosSinceEpoch,
-    unixEpoch,
+    days_in_month,
+    from_iso_str,
+    from_iso_u8,
+    from_nanos_since_epoch,
+    from_yd,
+    from_ymd,
+    from_yw,
+    from_ywd,
+    is_leap_year,
+    to_iso_str,
+    to_iso_u8,
+    to_nanos_since_epoch,
+    unix_epoch,
     weekday,
 ]
 
 import Const
-import Duration exposing [Duration, toNanoseconds, fromDays]
+import Duration exposing [Duration, to_nanoseconds, from_days]
 import Utils exposing [
-    expandIntWithZeros,
-    splitListAtIndices,
-    utf8ToInt,
-    utf8ToIntSigned,
-    validateUtf8SingleBytes,
+    expand_int_with_zeros,
+    split_list_at_indices,
+    utf8_to_int,
+    utf8_to_int_signed,
+    validate_utf8_single_bytes,
 ]
 import Unsafe exposing [unwrap] # for unit testing only
 
 ## ```
-## Date : { 
-##     year: I64, 
-##     month: U8, 
-##     dayOfMonth: U8, 
-##     dayOfYear: U16 
+## Date : {
+##     year: I64,
+##     month: U8,
+##     day_of_month: U8,
+##     day_of_year: U16
 ## }
 ## ```
-Date : { 
+Date : {
     year : I64,
-    month : U8, 
-    dayOfMonth : U8, 
-    dayOfYear : U16 
+    month : U8,
+    day_of_month : U8,
+    day_of_year : U16,
 }
 
 ## `Date` object representing the Unix epoch (1970-01-01).
-unixEpoch : Date
-unixEpoch = { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
+unix_epoch : Date
+unix_epoch = { year: 1970, month: 1, day_of_month: 1, day_of_year: 1 }
 
 ## Create a `Date` object from the given year and day of the year.
-fromYd : Int *, Int * -> Date
-fromYd = \year, dayOfYear ->
+from_yd : Int *, Int * -> Date
+from_yd = \year, day_of_year ->
     List.range { start: At 1, end: At 12 }
-    |> List.map \m -> Const.monthDays { month: Num.toU64 m, isLeap: isLeapYear year }
-    |> List.walkUntil { daysRemaining: Num.toU16 dayOfYear, month: 1 } walkUntilMonthFunc
-    |> \result -> { year: Num.toI64 year, month: Num.toU8 result.month, dayOfMonth: Num.toU8 result.daysRemaining, dayOfYear: Num.toU16 dayOfYear }
+    |> List.map \m -> Const.month_days { month: Num.toU64 m, is_leap: is_leap_year year }
+    |> List.walkUntil { days_remaining: Num.toU16 day_of_year, month: 1 } walk_until_month_func
+    |> \result -> { year: Num.toI64 year, month: Num.toU8 result.month, day_of_month: Num.toU8 result.days_remaining, day_of_year: Num.toU16 day_of_year }
 
 ## Check whether the given year is a leap year.
-isLeapYear = \year ->
+is_leap_year = \year ->
     (
         year
-        % Const.leapInterval
+        % Const.leap_interval
         == 0
         && year
-        % Const.leapException
+        % Const.leap_exception
         != 0
     )
     || year
-    % Const.leapNonException
+    % Const.leap_non_exception
     == 0
 
 ## Walk through the months of a year to find the month and day of the month
-walkUntilMonthFunc : { daysRemaining : U16, month : U8 }, U64 -> [Break { daysRemaining : U16, month : U8 }, Continue { daysRemaining : U16, month : U8 }]
-walkUntilMonthFunc = \state, currMonthDays ->
-    if state.daysRemaining <= Num.toU16 currMonthDays then
-        Break { daysRemaining: state.daysRemaining, month: state.month }
+walk_until_month_func : { days_remaining : U16, month : U8 }, U64 -> [Break { days_remaining : U16, month : U8 }, Continue { days_remaining : U16, month : U8 }]
+walk_until_month_func = \state, curr_month_days ->
+    if state.days_remaining <= Num.toU16 curr_month_days then
+        Break { days_remaining: state.days_remaining, month: state.month }
     else
-        Continue { daysRemaining: state.daysRemaining - Num.toU16 currMonthDays, month: state.month + 1 }
+        Continue { days_remaining: state.days_remaining - Num.toU16 curr_month_days, month: state.month + 1 }
 
 ## Create a `Date` object from the given year, month, and day of the month.
-fromYmd : Int *, Int *, Int * -> Date
-fromYmd = \year, month, day ->
-    { year: Num.toI64 year, month: Num.toU8 month, dayOfMonth: Num.toU8 day, dayOfYear: ymdToDaysInYear year month day }
+from_ymd : Int *, Int *, Int * -> Date
+from_ymd = \year, month, day ->
+    { year: Num.toI64 year, month: Num.toU8 month, day_of_month: Num.toU8 day, day_of_year: ymd_to_days_in_year year month day }
 
 ## Convert the given year, month, and day of the month to the day of the year.
-ymdToDaysInYear : Int *, Int *, Int * -> U16
-ymdToDaysInYear = \year, month, day ->
+ymd_to_days_in_year : Int *, Int *, Int * -> U16
+ymd_to_days_in_year = \year, month, day ->
     List.range { start: At 0, end: Before month }
-    |> List.map \m -> Const.monthDays { month: Num.toU64 m, isLeap: isLeapYear year }
+    |> List.map \m -> Const.month_days { month: Num.toU64 m, is_leap: is_leap_year year }
     |> List.sum
     |> Num.add (Num.toU64 day)
     |> Num.toU16
 
 ## Create a `Date` object from the given year, week, and day of the week.
-fromYwd : Int *, Int *, Int * -> Date
-fromYwd = \year, week, day ->
-    daysInYear = if isLeapYear year then 366 else 365
-    d = calendarWeekToDaysInYear week year |> Num.add (Num.toU64 day)
-    if d > daysInYear then
-        fromYd (year + 1) (d - daysInYear)
+from_ywd : Int *, Int *, Int * -> Date
+from_ywd = \year, week, day ->
+    days_in_year = if is_leap_year year then 366 else 365
+    d = calendar_week_to_days_in_year week year |> Num.add (Num.toU64 day)
+    if d > days_in_year then
+        from_yd (year + 1) (d - days_in_year)
     else
-        fromYd year d
+        from_yd year d
 
 ## Convert the given calendar week and year to the day of the year.
-calendarWeekToDaysInYear : Int *, Int * -> U64
-calendarWeekToDaysInYear = \week, year ->
+calendar_week_to_days_in_year : Int *, Int * -> U64
+calendar_week_to_days_in_year = \week, year ->
     # Week 1 of a year is the first week with a majority of its days in that year
     # https://en.wikipedia.org/wiki/ISO_week_date#First_week
     y = year |> Num.toU64
     w = week |> Num.toU64
-    lengthOfMaybeFirstWeek =
-        if y >= Const.epochYear then
-            Const.epochWeekOffset - (numDaysSinceEpochUntilYear (Num.toI64 y) |> Num.toU64) % 7
+    length_of_maybe_first_week =
+        if y >= Const.epoch_year then
+            Const.epoch_week_offset - (num_days_since_epoch_until_year (Num.toI64 y) |> Num.toU64) % 7
         else
-            (Const.epochWeekOffset + (numDaysSinceEpochUntilYear (Num.toI64 y) |> Num.abs |> Num.toU64)) % 7
-    if lengthOfMaybeFirstWeek >= 4 && w == 1 then
+            (Const.epoch_week_offset + (num_days_since_epoch_until_year (Num.toI64 y) |> Num.abs |> Num.toU64)) % 7
+    if length_of_maybe_first_week >= 4 && w == 1 then
         0
     else
-        (w - 1) * Const.daysPerWeek + lengthOfMaybeFirstWeek
+        (w - 1) * Const.days_per_week + length_of_maybe_first_week
 
 ## Calculate the number of leap years since the epoch.
-numLeapYearsSinceEpoch : I64, [IncludeCurrent, ExcludeCurrent] -> I64
-numLeapYearsSinceEpoch = \year, inclusive ->
-    leapIncr = isLeapYear year |> \isLeap -> if isLeap && inclusive == IncludeCurrent then 1 else 0
-    nextYear = if year > Const.epochYear then year - 1 else year + 1
+num_leap_years_since_epoch : I64, [IncludeCurrent, ExcludeCurrent] -> I64
+num_leap_years_since_epoch = \year, inclusive ->
+    leap_incr = is_leap_year year |> \is_leap -> if is_leap && inclusive == IncludeCurrent then 1 else 0
+    next_year = if year > Const.epoch_year then year - 1 else year + 1
     when inclusive is
-        ExcludeCurrent if year != Const.epochYear -> numLeapYearsSinceEpoch nextYear IncludeCurrent
+        ExcludeCurrent if year != Const.epoch_year -> num_leap_years_since_epoch next_year IncludeCurrent
         ExcludeCurrent -> 0
-        IncludeCurrent if year != Const.epochYear -> leapIncr + numLeapYearsSinceEpoch nextYear inclusive
-        IncludeCurrent -> leapIncr
+        IncludeCurrent if year != Const.epoch_year -> leap_incr + num_leap_years_since_epoch next_year inclusive
+        IncludeCurrent -> leap_incr
 
 ## Calculate the number of days since the epoch.
-numDaysSinceEpoch : Date -> I64
-numDaysSinceEpoch = \date ->
-    numLeapYears = numLeapYearsSinceEpoch date.year ExcludeCurrent
-    getMonthDays = \m -> Const.monthDays { month: m, isLeap: isLeapYear date.year }
-    if date.year >= Const.epochYear then
-        daysInYears = numLeapYears * 366 + (date.year - Const.epochYear - numLeapYears) * 365
-        List.map (List.range { start: At 1, end: Before date.month }) getMonthDays
+num_days_since_epoch : Date -> I64
+num_days_since_epoch = \date ->
+    num_leap_years = num_leap_years_since_epoch date.year ExcludeCurrent
+    get_month_days = \m -> Const.month_days { month: m, is_leap: is_leap_year date.year }
+    if date.year >= Const.epoch_year then
+        days_in_years = num_leap_years * 366 + (date.year - Const.epoch_year - num_leap_years) * 365
+        List.map (List.range { start: At 1, end: Before date.month }) get_month_days
         |> List.sum
         |> Num.toI64
-        |> Num.add (daysInYears + Num.toI64 date.dayOfMonth - 1)
+        |> Num.add (days_in_years + Num.toI64 date.day_of_month - 1)
     else
-        daysInYears = numLeapYears * 366 + (Const.epochYear - date.year - numLeapYears - 1) * 365
-        List.map (List.range { start: After date.month, end: At 12 }) getMonthDays
+        days_in_years = num_leap_years * 366 + (Const.epoch_year - date.year - num_leap_years - 1) * 365
+        List.map (List.range { start: After date.month, end: At 12 }) get_month_days
         |> List.sum
         |> Num.toI64
-        |> Num.add (daysInYears + Num.toI64 (getMonthDays date.month) - Num.toI64 date.dayOfMonth + 1)
+        |> Num.add (days_in_years + Num.toI64 (get_month_days date.month) - Num.toI64 date.day_of_month + 1)
         |> Num.mul -1
 
 ## Calculate the number of days since the epoch until the given year.
-numDaysSinceEpochUntilYear = \year ->
-    numDaysSinceEpoch { year, month: 1, dayOfMonth: 1, dayOfYear: 1 }
+num_days_since_epoch_until_year = \year ->
+    num_days_since_epoch { year, month: 1, day_of_month: 1, day_of_year: 1 }
 
 ## Return the day of the week, from 0=Sunday to 6=Saturday
 weekday : I64, U8, U8 -> U8
 weekday = \year, month, day ->
     year2xxx = (year % 400) + 2400 # to handle years before the epoch
-    date = Date.fromYmd year2xxx month day
-    daysSinceEpoch = Date.toNanosSinceEpoch date // Const.nanosPerDay
-    (daysSinceEpoch + 4) % 7 |> Num.toU8
+    date = Date.from_ymd year2xxx month day
+    days_since_epoch = Date.to_nanos_since_epoch date // Const.nanos_per_day
+    (days_since_epoch + 4) % 7 |> Num.toU8
 
 ## Returns the number of days in the given month of the given year.
-daysInMonth : I64, U8 -> U8
-daysInMonth = \year, month ->
-    Const.monthDays { month, isLeap: (isLeapYear year) } |> Num.toU8
+days_in_month : I64, U8 -> U8
+days_in_month = \year, month ->
+    Const.month_days { month, is_leap: is_leap_year year } |> Num.toU8
 
 ## Create a `Date` object from the given year and week.
-fromYw : Int *, Int * -> Date
-fromYw = \year, week ->
-    fromYwd year week 1
+from_yw : Int *, Int * -> Date
+from_yw = \year, week ->
+    from_ywd year week 1
 
 ## Convert the given `Date` to nanoseconds since the epoch.
-toNanosSinceEpoch : Date -> I128
-toNanosSinceEpoch = \date ->
-    days = numDaysSinceEpoch date
-    days |> Num.toI128 |> Num.mul Const.nanosPerDay
+to_nanos_since_epoch : Date -> I128
+to_nanos_since_epoch = \date ->
+    days = num_days_since_epoch date
+    days |> Num.toI128 |> Num.mul Const.nanos_per_day
 
 ## Create a `Date` object from the given nanoseconds since the epoch.
-fromNanosSinceEpoch : Int * -> Date
-fromNanosSinceEpoch = \nanos ->
-    days = nanos // Const.nanosPerDay |> \d -> if nanos % Const.nanosPerDay < 0 then d - 1 else d
-    fromNanosHelper (Num.toI128 days) 1970
+from_nanos_since_epoch : Int * -> Date
+from_nanos_since_epoch = \nanos ->
+    days = nanos // Const.nanos_per_day |> \d -> if nanos % Const.nanos_per_day < 0 then d - 1 else d
+    from_nanos_helper (Num.toI128 days) 1970
 
-fromNanosHelper : I128, I64 -> Date
-fromNanosHelper = \days, year ->
+from_nanos_helper : I128, I64 -> Date
+from_nanos_helper = \days, year ->
     if days < 0 then
-        fromNanosHelper (days + if isLeapYear (year - 1) then 366 else 365) (year - 1)
+        from_nanos_helper (days + if is_leap_year (year - 1) then 366 else 365) (year - 1)
     else
-        daysInYear = if isLeapYear year then 366 else 365
-        if days >= daysInYear then
-            fromNanosHelper (days - daysInYear) (year + 1)
+        days_in_year = if is_leap_year year then 366 else 365
+        if days >= days_in_year then
+            from_nanos_helper (days - days_in_year) (year + 1)
         else
-            fromYd year (days + 1)
+            from_yd year (days + 1)
 
 # TODO: allow for negative years
 ## Add the given number of years to the given `Date`.
-addYears : Date, Int * -> Date
-addYears = \date, years -> fromYmd (date.year + Num.toI64 years) date.month date.dayOfMonth
+add_years : Date, Int * -> Date
+add_years = \date, years -> from_ymd (date.year + Num.toI64 years) date.month date.day_of_month
 
 # TODO: allow for negative months
 ## Add the given number of months to the given `Date`.
-addMonths : Date, Int * -> Date
-addMonths = \date, months ->
-    newMonthWithOverflow = date.month + Num.toU8 months
-    newYear = date.year + Num.toI64 (newMonthWithOverflow // 12)
-    newMonth = newMonthWithOverflow % 12
-    newDay = (
-        if date.dayOfMonth > Num.toU8 (Const.monthDays { month: newMonth, isLeap: isLeapYear newYear }) then
-            Num.toU8 (Const.monthDays { month: newMonth, isLeap: isLeapYear newYear })
+add_months : Date, Int * -> Date
+add_months = \date, months ->
+    new_month_with_overflow = date.month + Num.toU8 months
+    new_year = date.year + Num.toI64 (new_month_with_overflow // 12)
+    new_month = new_month_with_overflow % 12
+    new_day = (
+        if date.day_of_month > Num.toU8 (Const.month_days { month: new_month, is_leap: is_leap_year new_year }) then
+            Num.toU8 (Const.month_days { month: new_month, is_leap: is_leap_year new_year })
         else
-            date.dayOfMonth
+            date.day_of_month
     )
-    fromYmd newYear newMonth newDay
+    from_ymd new_year new_month new_day
 
 ## Add the given number of days to the given `Date`.
-addDays : Date, Int * -> Date
-addDays = \date, days ->
-    addDaysHelper date (Num.toI16 days)
+add_days : Date, Int * -> Date
+add_days = \date, days ->
+    add_days_helper date (Num.toI16 days)
 
-addDaysHelper : Date, I16 -> Date
-addDaysHelper = \date, days ->
-    daysInYear = if isLeapYear date.year then 366 else 365
-    newDayOfYear = (Num.toI16 date.dayOfYear) + days
-    if newDayOfYear > daysInYear then
-        addDaysHelper { year: date.year + 1, month: 1, dayOfMonth: 1, dayOfYear: 0 } (newDayOfYear - daysInYear)
-    else if newDayOfYear < 1 then
-        daysInPrevYear = if isLeapYear (date.year - 1) then 366 else 365
-        addDaysHelper { year: date.year - 1, month: 12, dayOfMonth: 31, dayOfYear: 0 } (newDayOfYear + Num.toI16 daysInPrevYear)
+add_days_helper : Date, I16 -> Date
+add_days_helper = \date, days ->
+    days_in_year = if is_leap_year date.year then 366 else 365
+    new_day_of_year = (Num.toI16 date.day_of_year) + days
+    if new_day_of_year > days_in_year then
+        add_days_helper { year: date.year + 1, month: 1, day_of_month: 1, day_of_year: 0 } (new_day_of_year - days_in_year)
+    else if new_day_of_year < 1 then
+        days_in_prev_year = if is_leap_year (date.year - 1) then 366 else 365
+        add_days_helper { year: date.year - 1, month: 12, day_of_month: 31, day_of_year: 0 } (new_day_of_year + Num.toI16 days_in_prev_year)
     else
-        fromYd date.year newDayOfYear
+        from_yd date.year new_day_of_year
 
 ## Add the given `Duration` to the given `Date`.
-addDurationAndDate : Duration, Date -> Date
-addDurationAndDate = \duration, date ->
-    durationNanos = toNanoseconds duration
-    dateNanos = toNanosSinceEpoch date |> Num.toI128
-    durationNanos + dateNanos |> fromNanosSinceEpoch
+add_duration_and_date : Duration, Date -> Date
+add_duration_and_date = \duration, date ->
+    duration_nanos = to_nanoseconds duration
+    date_nanos = to_nanos_since_epoch date |> Num.toI128
+    duration_nanos + date_nanos |> from_nanos_since_epoch
 
 ## Add the given `Date` and `Duration`.
-addDateAndDuration : Date, Duration -> Date
-addDateAndDuration = \date, duration -> addDurationAndDate duration date
+add_date_and_duration : Date, Duration -> Date
+add_date_and_duration = \date, duration -> add_duration_and_date duration date
 
 ## Convert the given `Date` to an ISO 8601 string.
-toIsoStr : Date -> Str
-toIsoStr = \date ->
-    expandIntWithZeros date.year 4
+to_iso_str : Date -> Str
+to_iso_str = \date ->
+    expand_int_with_zeros date.year 4
     |> Str.concat "-"
-    |> Str.concat (expandIntWithZeros date.month 2)
+    |> Str.concat (expand_int_with_zeros date.month 2)
     |> Str.concat "-"
-    |> Str.concat (expandIntWithZeros date.dayOfMonth 2)
+    |> Str.concat (expand_int_with_zeros date.day_of_month 2)
 
 ## Convert the `Date` to an ISO 8601 string as a list of UTF-8 bytes.
-toIsoU8 : Date -> List U8
-toIsoU8 = \date -> toIsoStr date |> Str.toUtf8
+to_iso_u8 : Date -> List U8
+to_iso_u8 = \date -> to_iso_str date |> Str.toUtf8
 
 ## Convert the given ISO 8601 string to a `Date`.
-fromIsoStr : Str -> Result Date [InvalidDateFormat]
-fromIsoStr = \str -> Str.toUtf8 str |> fromIsoU8
+from_iso_str : Str -> Result Date [InvalidDateFormat]
+from_iso_str = \str -> Str.toUtf8 str |> from_iso_u8
 
 # TODO: More efficient parsing method?
 ## Convert the given ISO 8601 list of UTF-8 bytes to a `Date`.
-fromIsoU8 : List U8 -> Result Date [InvalidDateFormat]
-fromIsoU8 = \bytes ->
-    if validateUtf8SingleBytes bytes then
+from_iso_u8 : List U8 -> Result Date [InvalidDateFormat]
+from_iso_u8 = \bytes ->
+    if validate_utf8_single_bytes bytes then
         when bytes is
-            [_, _] -> parseCalendarDateCentury bytes # YY
-            [_, _, _, _] -> parseCalendarDateYear bytes # YYYY
-            [_, _, _, _, 'W', _, _] -> parseWeekDateReducedBasic bytes # YYYYWww
-            [_, _, _, _, '-', _, _] -> parseCalendarDateMonth bytes # YYYY-MM
-            [_, _, _, _, _, _, _] -> parseOrdinalDateBasic bytes # YYYYDDD
-            [_, _, _, _, '-', 'W', _, _] -> parseWeekDateReducedExtended bytes # YYYY-Www
-            [_, _, _, _, 'W', _, _, _] -> parseWeekDateBasic bytes # YYYYWwwD
-            [_, _, _, _, '-', _, _, _] -> parseOrdinalDateExtended bytes # YYYY-DDD
-            [_, _, _, _, _, _, _, _] -> parseCalendarDateBasic bytes # YYYYMMDD
-            [_, _, _, _, '-', 'W', _, _, '-', _] -> parseWeekDateExtended bytes # YYYY-Www-D
-            [_, _, _, _, '-', _, _, '-', _, _] -> parseCalendarDateExtended bytes # YYYY-MM-DD
+            [_, _] -> parse_calendar_date_century bytes # YY
+            [_, _, _, _] -> parse_calendar_date_year bytes # YYYY
+            [_, _, _, _, 'W', _, _] -> parse_week_date_reduced_basic bytes # YYYYWww
+            [_, _, _, _, '-', _, _] -> parse_calendar_date_month bytes # YYYY-MM
+            [_, _, _, _, _, _, _] -> parse_ordinal_date_basic bytes # YYYYDDD
+            [_, _, _, _, '-', 'W', _, _] -> parse_week_date_reduced_extended bytes # YYYY-Www
+            [_, _, _, _, 'W', _, _, _] -> parse_week_date_basic bytes # YYYYWwwD
+            [_, _, _, _, '-', _, _, _] -> parse_ordinal_date_extended bytes # YYYY-DDD
+            [_, _, _, _, _, _, _, _] -> parse_calendar_date_basic bytes # YYYYMMDD
+            [_, _, _, _, '-', 'W', _, _, '-', _] -> parse_week_date_extended bytes # YYYY-Www-D
+            [_, _, _, _, '-', _, _, '-', _, _] -> parse_calendar_date_extended bytes # YYYY-MM-DD
             _ -> Err InvalidDateFormat
     else
         Err InvalidDateFormat
 
-parseCalendarDateBasic : List U8 -> Result Date [InvalidDateFormat]
-parseCalendarDateBasic = \bytes ->
-    when splitListAtIndices bytes [4, 6] is
-        [yearBytes, monthBytes, dayBytes] ->
-            when (utf8ToInt yearBytes, utf8ToInt monthBytes, utf8ToInt dayBytes) is
+parse_calendar_date_basic : List U8 -> Result Date [InvalidDateFormat]
+parse_calendar_date_basic = \bytes ->
+    when split_list_at_indices bytes [4, 6] is
+        [year_bytes, month_bytes, day_bytes] ->
+            when (utf8_to_int year_bytes, utf8_to_int month_bytes, utf8_to_int day_bytes) is
                 (Ok y, Ok m, Ok d) if m >= 1 && m <= 12 && d >= 1 && d <= 31 ->
-                    Date.fromYmd y m d |> Ok
+                    Date.from_ymd y m d |> Ok
 
                 (_, _, _) -> Err InvalidDateFormat
 
         _ -> Err InvalidDateFormat
 
-parseCalendarDateExtended : List U8 -> Result Date [InvalidDateFormat]
-parseCalendarDateExtended = \bytes ->
-    when splitListAtIndices bytes [4, 5, 7, 8] is
-        [yearBytes, _, monthBytes, _, dayBytes] ->
-            when (utf8ToIntSigned yearBytes, utf8ToInt monthBytes, utf8ToInt dayBytes) is
+parse_calendar_date_extended : List U8 -> Result Date [InvalidDateFormat]
+parse_calendar_date_extended = \bytes ->
+    when split_list_at_indices bytes [4, 5, 7, 8] is
+        [year_bytes, _, month_bytes, _, day_bytes] ->
+            when (utf8_to_int_signed year_bytes, utf8_to_int month_bytes, utf8_to_int day_bytes) is
                 (Ok y, Ok m, Ok d) if m >= 1 && m <= 12 && d >= 1 && d <= 31 ->
-                    Date.fromYmd y m d |> Ok
+                    Date.from_ymd y m d |> Ok
 
                 (_, _, _) -> Err InvalidDateFormat
 
         _ -> Err InvalidDateFormat
 
-parseCalendarDateCentury : List U8 -> Result Date [InvalidDateFormat]
-parseCalendarDateCentury = \bytes ->
-    when utf8ToIntSigned bytes is
-        Ok century -> Date.fromYmd (century * 100) 1 1 |> Ok
+parse_calendar_date_century : List U8 -> Result Date [InvalidDateFormat]
+parse_calendar_date_century = \bytes ->
+    when utf8_to_int_signed bytes is
+        Ok century -> Date.from_ymd (century * 100) 1 1 |> Ok
         Err _ -> Err InvalidDateFormat
 
-parseCalendarDateYear : List U8 -> Result Date [InvalidDateFormat]
-parseCalendarDateYear = \bytes ->
-    when utf8ToIntSigned bytes is
-        Ok year -> Date.fromYmd year 1 1 |> Ok
+parse_calendar_date_year : List U8 -> Result Date [InvalidDateFormat]
+parse_calendar_date_year = \bytes ->
+    when utf8_to_int_signed bytes is
+        Ok year -> Date.from_ymd year 1 1 |> Ok
         Err _ -> Err InvalidDateFormat
 
-parseCalendarDateMonth : List U8 -> Result Date [InvalidDateFormat]
-parseCalendarDateMonth = \bytes ->
-    when splitListAtIndices bytes [4, 5] is
-        [yearBytes, _, monthBytes] ->
-            when (utf8ToIntSigned yearBytes, utf8ToInt monthBytes) is
+parse_calendar_date_month : List U8 -> Result Date [InvalidDateFormat]
+parse_calendar_date_month = \bytes ->
+    when split_list_at_indices bytes [4, 5] is
+        [year_bytes, _, month_bytes] ->
+            when (utf8_to_int_signed year_bytes, utf8_to_int month_bytes) is
                 (Ok year, Ok month) if month >= 1 && month <= 12 ->
-                    Date.fromYmd year month 1 |> Ok
+                    Date.from_ymd year month 1 |> Ok
 
                 (_, _) -> Err InvalidDateFormat
 
         _ -> Err InvalidDateFormat
 
-parseOrdinalDateBasic : List U8 -> Result Date [InvalidDateFormat]
-parseOrdinalDateBasic = \bytes ->
-    when splitListAtIndices bytes [4] is
-        [yearBytes, dayBytes] ->
-            when (utf8ToIntSigned yearBytes, utf8ToInt dayBytes) is
+parse_ordinal_date_basic : List U8 -> Result Date [InvalidDateFormat]
+parse_ordinal_date_basic = \bytes ->
+    when split_list_at_indices bytes [4] is
+        [year_bytes, day_bytes] ->
+            when (utf8_to_int_signed year_bytes, utf8_to_int day_bytes) is
                 (Ok year, Ok day) if day >= 1 && day <= 366 ->
-                    Date.fromYd year day |> Ok
+                    Date.from_yd year day |> Ok
 
                 (_, _) -> Err InvalidDateFormat
 
         _ -> Err InvalidDateFormat
 
-parseOrdinalDateExtended : List U8 -> Result Date [InvalidDateFormat]
-parseOrdinalDateExtended = \bytes ->
-    when splitListAtIndices bytes [4, 5] is
-        [yearBytes, _, dayBytes] ->
-            when (utf8ToIntSigned yearBytes, utf8ToInt dayBytes) is
+parse_ordinal_date_extended : List U8 -> Result Date [InvalidDateFormat]
+parse_ordinal_date_extended = \bytes ->
+    when split_list_at_indices bytes [4, 5] is
+        [year_bytes, _, day_bytes] ->
+            when (utf8_to_int_signed year_bytes, utf8_to_int day_bytes) is
                 (Ok year, Ok day) if day >= 1 && day <= 366 ->
-                    Date.fromYd year day |> Ok
+                    Date.from_yd year day |> Ok
 
                 (_, _) -> Err InvalidDateFormat
 
         _ -> Err InvalidDateFormat
 
-parseWeekDateBasic : List U8 -> Result Date [InvalidDateFormat]
-parseWeekDateBasic = \bytes ->
-    when splitListAtIndices bytes [4, 5, 7] is
-        [yearBytes, _, weekBytes, dayBytes] ->
-            when (utf8ToInt yearBytes, utf8ToInt weekBytes, utf8ToInt dayBytes) is
+parse_week_date_basic : List U8 -> Result Date [InvalidDateFormat]
+parse_week_date_basic = \bytes ->
+    when split_list_at_indices bytes [4, 5, 7] is
+        [year_bytes, _, week_bytes, day_bytes] ->
+            when (utf8_to_int year_bytes, utf8_to_int week_bytes, utf8_to_int day_bytes) is
                 (Ok y, Ok w, Ok d) if w >= 1 && w <= 52 && d >= 1 && d <= 7 ->
-                    Date.fromYwd y w d |> Ok
+                    Date.from_ywd y w d |> Ok
 
                 (_, _, _) -> Err InvalidDateFormat
 
         _ -> Err InvalidDateFormat
 
-parseWeekDateExtended : List U8 -> Result Date [InvalidDateFormat]
-parseWeekDateExtended = \bytes ->
-    when splitListAtIndices bytes [4, 6, 8, 9] is
-        [yearBytes, _, weekBytes, _, dayBytes] ->
-            when (utf8ToInt yearBytes, utf8ToInt weekBytes, utf8ToInt dayBytes) is
+parse_week_date_extended : List U8 -> Result Date [InvalidDateFormat]
+parse_week_date_extended = \bytes ->
+    when split_list_at_indices bytes [4, 6, 8, 9] is
+        [year_bytes, _, week_bytes, _, day_bytes] ->
+            when (utf8_to_int year_bytes, utf8_to_int week_bytes, utf8_to_int day_bytes) is
                 (Ok y, Ok w, Ok d) if w >= 1 && w <= 52 && d >= 1 && d <= 7 ->
-                    Date.fromYwd y w d |> Ok
+                    Date.from_ywd y w d |> Ok
 
                 (_, _, _) -> Err InvalidDateFormat
 
         _ -> Err InvalidDateFormat
 
-parseWeekDateReducedBasic : List U8 -> Result Date [InvalidDateFormat]
-parseWeekDateReducedBasic = \bytes ->
-    when splitListAtIndices bytes [4, 5] is
-        [yearBytes, _, weekBytes] ->
-            when (utf8ToInt yearBytes, utf8ToInt weekBytes) is
+parse_week_date_reduced_basic : List U8 -> Result Date [InvalidDateFormat]
+parse_week_date_reduced_basic = \bytes ->
+    when split_list_at_indices bytes [4, 5] is
+        [year_bytes, _, week_bytes] ->
+            when (utf8_to_int year_bytes, utf8_to_int week_bytes) is
                 (Ok year, Ok week) if week >= 1 && week <= 52 ->
-                    Date.fromYw year week |> Ok
+                    Date.from_yw year week |> Ok
 
                 (_, _) -> Err InvalidDateFormat
 
         _ -> Err InvalidDateFormat
 
-parseWeekDateReducedExtended : List U8 -> Result Date [InvalidDateFormat]
-parseWeekDateReducedExtended = \bytes ->
-    when splitListAtIndices bytes [4, 6] is
-        [yearBytes, _, weekBytes] ->
-            when (utf8ToInt yearBytes, utf8ToInt weekBytes) is
+parse_week_date_reduced_extended : List U8 -> Result Date [InvalidDateFormat]
+parse_week_date_reduced_extended = \bytes ->
+    when split_list_at_indices bytes [4, 6] is
+        [year_bytes, _, week_bytes] ->
+            when (utf8_to_int year_bytes, utf8_to_int week_bytes) is
                 (Ok year, Ok week) if week >= 1 && week <= 52 ->
-                    Date.fromYw year week |> Ok
+                    Date.from_yw year week |> Ok
 
                 (_, _) -> Err InvalidDateFormat
 
@@ -408,96 +408,95 @@ parseWeekDateReducedExtended = \bytes ->
 
 # <==== TESTS ====>
 # <---- fromYd ---->
-expect fromYd 1970 1 == { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
-expect fromYd 1970 31 == { year: 1970, month: 1, dayOfMonth: 31, dayOfYear: 31 }
-expect fromYd 1970 32 == { year: 1970, month: 2, dayOfMonth: 1, dayOfYear: 32 }
-expect fromYd 1970 60 == { year: 1970, month: 3, dayOfMonth: 1, dayOfYear: 60 }
-expect fromYd 1972 61 == { year: 1972, month: 3, dayOfMonth: 1, dayOfYear: 61 }
+expect from_yd 1970 1 == { year: 1970, month: 1, day_of_month: 1, day_of_year: 1 }
+expect from_yd 1970 31 == { year: 1970, month: 1, day_of_month: 31, day_of_year: 31 }
+expect from_yd 1970 32 == { year: 1970, month: 2, day_of_month: 1, day_of_year: 32 }
+expect from_yd 1970 60 == { year: 1970, month: 3, day_of_month: 1, day_of_year: 60 }
+expect from_yd 1972 61 == { year: 1972, month: 3, day_of_month: 1, day_of_year: 61 }
 
 # <---- calendarWeekToDaysInYear ---->
-expect calendarWeekToDaysInYear 1 1965 == 3
-expect calendarWeekToDaysInYear 1 1964 == 0
-expect calendarWeekToDaysInYear 1 1970 == 0
-expect calendarWeekToDaysInYear 1 1971 == 3
-expect calendarWeekToDaysInYear 1 1972 == 2
-expect calendarWeekToDaysInYear 1 1973 == 0
-expect calendarWeekToDaysInYear 2 2024 == 7
+expect calendar_week_to_days_in_year 1 1965 == 3
+expect calendar_week_to_days_in_year 1 1964 == 0
+expect calendar_week_to_days_in_year 1 1970 == 0
+expect calendar_week_to_days_in_year 1 1971 == 3
+expect calendar_week_to_days_in_year 1 1972 == 2
+expect calendar_week_to_days_in_year 1 1973 == 0
+expect calendar_week_to_days_in_year 2 2024 == 7
 
 # <---- numDaysSinceEpoch ---->
-expect numDaysSinceEpoch (fromYmd 2024 1 1) == 19723 # Removed due to compiler bug with optional record fields
-expect numDaysSinceEpoch (fromYmd 1970 12 31) == 365 - 1
-expect numDaysSinceEpoch (fromYmd 1971 1 2) == 365 + 1
-expect numDaysSinceEpoch (fromYmd 2024 1 1) == 19723
-expect numDaysSinceEpoch (fromYmd 2024 2 1) == 19723 + 31
-expect numDaysSinceEpoch (fromYmd 2024 12 31) == 19723 + 366 - 1
-expect numDaysSinceEpoch (fromYmd 1969 12 31) == -1
-expect numDaysSinceEpoch (fromYmd 1969 12 30) == -2
-expect numDaysSinceEpoch (fromYmd 1969 1 1) == -365
-expect numDaysSinceEpoch (fromYmd 1968 1 1) == -365 - 366
+expect num_days_since_epoch (from_ymd 2024 1 1) == 19723 # Removed due to compiler bug with optional record fields
+expect num_days_since_epoch (from_ymd 1970 12 31) == 365 - 1
+expect num_days_since_epoch (from_ymd 1971 1 2) == 365 + 1
+expect num_days_since_epoch (from_ymd 2024 1 1) == 19723
+expect num_days_since_epoch (from_ymd 2024 2 1) == 19723 + 31
+expect num_days_since_epoch (from_ymd 2024 12 31) == 19723 + 366 - 1
+expect num_days_since_epoch (from_ymd 1969 12 31) == -1
+expect num_days_since_epoch (from_ymd 1969 12 30) == -2
+expect num_days_since_epoch (from_ymd 1969 1 1) == -365
+expect num_days_since_epoch (from_ymd 1968 1 1) == -365 - 366
 
 # <---- numDaysSinceEpochToYear ---->
-expect numDaysSinceEpochUntilYear 1968 == -365 - 366
-expect numDaysSinceEpochUntilYear 1970 == 0
-expect numDaysSinceEpochUntilYear 1971 == 365
-expect numDaysSinceEpochUntilYear 1972 == 365 + 365
-expect numDaysSinceEpochUntilYear 1973 == 365 + 365 + 366
-expect numDaysSinceEpochUntilYear 2024 == 19723
+expect num_days_since_epoch_until_year 1968 == -365 - 366
+expect num_days_since_epoch_until_year 1970 == 0
+expect num_days_since_epoch_until_year 1971 == 365
+expect num_days_since_epoch_until_year 1972 == 365 + 365
+expect num_days_since_epoch_until_year 1973 == 365 + 365 + 366
+expect num_days_since_epoch_until_year 2024 == 19723
 
 # <---- fromYmd ---->
-expect fromYmd 1970 1 1 == { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
-expect fromYmd 1970 12 31 == { year: 1970, month: 12, dayOfMonth: 31, dayOfYear: 365 }
-expect fromYmd 1972 3 1 == { year: 1972, month: 3, dayOfMonth: 1, dayOfYear: 61 }
+expect from_ymd 1970 1 1 == { year: 1970, month: 1, day_of_month: 1, day_of_year: 1 }
+expect from_ymd 1970 12 31 == { year: 1970, month: 12, day_of_month: 31, day_of_year: 365 }
+expect from_ymd 1972 3 1 == { year: 1972, month: 3, day_of_month: 1, day_of_year: 61 }
 
 # <---- fromYwd ---->
-expect fromYwd 1970 1 1 == { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
-expect fromYwd 1970 52 5 == { year: 1971, month: 1, dayOfMonth: 1, dayOfYear: 1 }
+expect from_ywd 1970 1 1 == { year: 1970, month: 1, day_of_month: 1, day_of_year: 1 }
+expect from_ywd 1970 52 5 == { year: 1971, month: 1, day_of_month: 1, day_of_year: 1 }
 
 # <---- fromYw ---->
-expect fromYw 1970 1 == { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
-expect fromYw 1971 1 == { year: 1971, month: 1, dayOfMonth: 4, dayOfYear: 4 }
+expect from_yw 1970 1 == { year: 1970, month: 1, day_of_month: 1, day_of_year: 1 }
+expect from_yw 1971 1 == { year: 1971, month: 1, day_of_month: 4, day_of_year: 4 }
 
 # <---- fromNanosSinceEpoch ---->
-expect fromNanosSinceEpoch 0 == { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 }
-expect fromNanosSinceEpoch (Const.nanosPerDay * 365) == { year: 1971, month: 1, dayOfMonth: 1, dayOfYear: 1 }
-expect fromNanosSinceEpoch (Const.nanosPerDay * 365 * 2 + Const.nanosPerDay * 366) == { year: 1973, month: 1, dayOfMonth: 1, dayOfYear: 1 }
-expect fromNanosSinceEpoch (-Const.nanosPerDay) == { year: 1969, month: 12, dayOfMonth: 31, dayOfYear: 365 }
-expect fromNanosSinceEpoch (-Const.nanosPerDay * 365) == { year: 1969, month: 1, dayOfMonth: 1, dayOfYear: 1 }
-expect fromNanosSinceEpoch (-Const.nanosPerDay * 365 - Const.nanosPerDay * 366) == { year: 1968, month: 1, dayOfMonth: 1, dayOfYear: 1 }
-expect fromNanosSinceEpoch -1 == { year: 1969, month: 12, dayOfMonth: 31, dayOfYear: 365 }
+expect from_nanos_since_epoch 0 == { year: 1970, month: 1, day_of_month: 1, day_of_year: 1 }
+expect from_nanos_since_epoch (Const.nanos_per_day * 365) == { year: 1971, month: 1, day_of_month: 1, day_of_year: 1 }
+expect from_nanos_since_epoch (Const.nanos_per_day * 365 * 2 + Const.nanos_per_day * 366) == { year: 1973, month: 1, day_of_month: 1, day_of_year: 1 }
+expect from_nanos_since_epoch (-Const.nanos_per_day) == { year: 1969, month: 12, day_of_month: 31, day_of_year: 365 }
+expect from_nanos_since_epoch ((-Const.nanos_per_day) * 365) == { year: 1969, month: 1, day_of_month: 1, day_of_year: 1 }
+expect from_nanos_since_epoch ((-Const.nanos_per_day) * 365 - Const.nanos_per_day * 366) == { year: 1968, month: 1, day_of_month: 1, day_of_year: 1 }
+expect from_nanos_since_epoch -1 == { year: 1969, month: 12, day_of_month: 31, day_of_year: 365 }
 
 # <---- toNanosSinceEpoch ---->
-expect toNanosSinceEpoch { year: 1970, month: 1, dayOfMonth: 1, dayOfYear: 1 } == 0
-expect toNanosSinceEpoch { year: 1970, month: 12, dayOfMonth: 31, dayOfYear: 365 } == Const.nanosPerHour * 24 * 364
-expect toNanosSinceEpoch { year: 1973, month: 1, dayOfMonth: 1, dayOfYear: 1 } == Const.nanosPerHour * 24 * 365 * 2 + Const.nanosPerHour * 24 * 366
-expect toNanosSinceEpoch { year: 1969, month: 12, dayOfMonth: 31, dayOfYear: 365 } == Const.nanosPerHour * 24 * -1
-expect toNanosSinceEpoch { year: 1969, month: 1, dayOfMonth: 1, dayOfYear: 1 } == Const.nanosPerHour * 24 * -365
-expect toNanosSinceEpoch { year: 1968, month: 1, dayOfMonth: 1, dayOfYear: 1 } == Const.nanosPerHour * 24 * -365 - Const.nanosPerHour * 24 * 366
+expect to_nanos_since_epoch { year: 1970, month: 1, day_of_month: 1, day_of_year: 1 } == 0
+expect to_nanos_since_epoch { year: 1970, month: 12, day_of_month: 31, day_of_year: 365 } == Const.nanos_per_hour * 24 * 364
+expect to_nanos_since_epoch { year: 1973, month: 1, day_of_month: 1, day_of_year: 1 } == Const.nanos_per_hour * 24 * 365 * 2 + Const.nanos_per_hour * 24 * 366
+expect to_nanos_since_epoch { year: 1969, month: 12, day_of_month: 31, day_of_year: 365 } == Const.nanos_per_hour * 24 * -1
+expect to_nanos_since_epoch { year: 1969, month: 1, day_of_month: 1, day_of_year: 1 } == Const.nanos_per_hour * 24 * -365
+expect to_nanos_since_epoch { year: 1968, month: 1, day_of_month: 1, day_of_year: 1 } == Const.nanos_per_hour * 24 * -365 - Const.nanos_per_hour * 24 * 366
 
 # <---- toIsoStr ---->
-expect toIsoStr unixEpoch == "1970-01-01"
+expect to_iso_str unix_epoch == "1970-01-01"
 
 # <---- addMonths ---->
-expect addMonths unixEpoch 12 == fromYmd 1971 1 1
-expect addMonths (fromYmd 1970 1 31) 1 == fromYmd 1970 2 28
-expect addMonths (fromYmd 1972 2 29) 12 == fromYmd 1973 2 28
+expect add_months unix_epoch 12 == from_ymd 1971 1 1
+expect add_months (from_ymd 1970 1 31) 1 == from_ymd 1970 2 28
+expect add_months (from_ymd 1972 2 29) 12 == from_ymd 1973 2 28
 
 # <---- addDays ---->
-expect addDays unixEpoch 365 == fromYmd 1971 1 1
-expect addDays unixEpoch (365 * 2) == fromYmd 1972 1 1
-expect addDays unixEpoch (365 * 2 + 366) == fromYmd 1973 1 1
-expect addDays unixEpoch (-1) == fromYmd 1969 12 31
-expect addDays unixEpoch (-365) == fromYmd 1969 1 1
-expect addDays unixEpoch (-365 - 1) == fromYmd 1968 12 31
-expect addDays unixEpoch (-365 - 366) == fromYmd 1968 1 1
+expect add_days unix_epoch 365 == from_ymd 1971 1 1
+expect add_days unix_epoch (365 * 2) == from_ymd 1972 1 1
+expect add_days unix_epoch (365 * 2 + 366) == from_ymd 1973 1 1
+expect add_days unix_epoch (-1) == from_ymd 1969 12 31
+expect add_days unix_epoch (-365) == from_ymd 1969 1 1
+expect add_days unix_epoch (-365 - 1) == from_ymd 1968 12 31
+expect add_days unix_epoch (-365 - 366) == from_ymd 1968 1 1
 
 # <---- addDateAndDuration ---->
-expect
-    addDateAndDuration unixEpoch (fromDays 1 |> unwrap "will not overflow") == fromYmd 1970 1 2
+expect add_date_and_duration unix_epoch (from_days 1 |> unwrap "will not overflow") == from_ymd 1970 1 2
 
 # <---- ymdToDaysInYear ---->
-expect ymdToDaysInYear 1970 1 1 == 1
-expect ymdToDaysInYear 1970 12 31 == 365
-expect ymdToDaysInYear 1972 3 1 == 61
+expect ymd_to_days_in_year 1970 1 1 == 1
+expect ymd_to_days_in_year 1970 12 31 == 365
+expect ymd_to_days_in_year 1972 3 1 == 61
 
 # <---- weekday ---->
 expect weekday 1964 10 10 == 6
@@ -506,16 +505,16 @@ expect weekday 1964 10 12 == 1
 expect weekday 2024 10 12 == 6
 
 # <---- daysInMonth ---->
-expect daysInMonth 1969 1 == 31
-expect daysInMonth 1969 2 == 28
-expect daysInMonth 1969 3 == 31
-expect daysInMonth 1969 4 == 30
-expect daysInMonth 1969 5 == 31
-expect daysInMonth 1969 6 == 30
-expect daysInMonth 1969 7 == 31
-expect daysInMonth 1969 8 == 31
-expect daysInMonth 1969 9 == 30
-expect daysInMonth 1969 10 == 31
-expect daysInMonth 1969 11 == 30
-expect daysInMonth 1969 12 == 31
-expect daysInMonth 2024 2 == 29
+expect days_in_month 1969 1 == 31
+expect days_in_month 1969 2 == 28
+expect days_in_month 1969 3 == 31
+expect days_in_month 1969 4 == 30
+expect days_in_month 1969 5 == 31
+expect days_in_month 1969 6 == 30
+expect days_in_month 1969 7 == 31
+expect days_in_month 1969 8 == 31
+expect days_in_month 1969 9 == 30
+expect days_in_month 1969 10 == 31
+expect days_in_month 1969 11 == 30
+expect days_in_month 1969 12 == 31
+expect days_in_month 2024 2 == 29

--- a/package/DateTime.roc
+++ b/package/DateTime.roc
@@ -2,29 +2,29 @@
 ##
 ## These functions include functions for creating `DateTime` objects from various numeric values, converting `DateTime`s to and from ISO 8601 strings, and performing arithmetic operations on `DateTime`s.
 module [
-    addDateTimeAndDuration,
-    addDays,
-    addDurationAndDateTime,
-    addHours,
-    addMinutes,
-    addMonths,
-    addNanoseconds,
-    addSeconds,
-    addYears,
+    add_date_time_and_duration,
+    add_days,
+    add_duration_and_date_time,
+    add_hours,
+    add_minutes,
+    add_months,
+    add_nanoseconds,
+    add_seconds,
+    add_years,
     DateTime,
-    fromIsoStr,
-    fromIsoU8,
-    fromNanosSinceEpoch,
-    fromYd,
-    fromYmd,
-    fromYw,
-    fromYwd,
-    fromYmdhms,
-    fromYmdhmsn,
-    toIsoStr,
-    toIsoU8,
-    toNanosSinceEpoch,
-    unixEpoch,
+    from_iso_str,
+    from_iso_u8,
+    from_nanos_since_epoch,
+    from_yd,
+    from_ymd,
+    from_yw,
+    from_ywd,
+    from_ymdhms,
+    from_ymdhmsn,
+    to_iso_str,
+    to_iso_u8,
+    to_nanos_since_epoch,
+    unix_epoch,
 ]
 
 import Const
@@ -35,7 +35,7 @@ import Duration exposing [Duration]
 import Time
 import Time exposing [Time]
 import Utils exposing [
-    splitUtf8AndKeepDelimiters,
+    split_utf8_and_keep_delimiters,
 ]
 import Unsafe exposing [unwrap] # for unit testing only
 
@@ -45,184 +45,184 @@ import Unsafe exposing [unwrap] # for unit testing only
 DateTime : { date : Date, time : Time }
 
 ## `DateTime` object representing the Unix epoch (1970-01-01T00:00:00).
-unixEpoch : DateTime
-unixEpoch = { date: Date.unixEpoch, time: Time.midnight }
+unix_epoch : DateTime
+unix_epoch = { date: Date.unix_epoch, time: Time.midnight }
 
 normalize : DateTime -> DateTime
-normalize = \dateTime ->
-    addHours
+normalize = \date_time ->
+    add_hours
         {
-            date: dateTime.date,
-            time: Time.fromHmsn 0 dateTime.time.minute dateTime.time.second dateTime.time.nanosecond,
+            date: date_time.date,
+            time: Time.from_hmsn 0 date_time.time.minute date_time.time.second date_time.time.nanosecond,
         }
-        dateTime.time.hour
+        date_time.time.hour
 
-expect normalize (fromYmdhmsn 1970 1 2 -12 1 2 3) == fromYmdhmsn 1970 1 1 12 1 2 3
-expect normalize (fromYmdhmsn 1970 1 1 12 1 2 3) == fromYmdhmsn 1970 1 1 12 1 2 3
-expect normalize (fromYmdhmsn 1970 1 1 36 1 2 3) == fromYmdhmsn 1970 1 2 12 1 2 3
+expect normalize (from_ymdhmsn 1970 1 2 -12 1 2 3) == from_ymdhmsn 1970 1 1 12 1 2 3
+expect normalize (from_ymdhmsn 1970 1 1 12 1 2 3) == from_ymdhmsn 1970 1 1 12 1 2 3
+expect normalize (from_ymdhmsn 1970 1 1 36 1 2 3) == from_ymdhmsn 1970 1 2 12 1 2 3
 
 ## Create a `DateTime` object from the year and day of the year.
-fromYd : Int *, Int * -> DateTime
-fromYd = \year, day -> { date: Date.fromYd year day, time: Time.midnight }
+from_yd : Int *, Int * -> DateTime
+from_yd = \year, day -> { date: Date.from_yd year day, time: Time.midnight }
 
 ## Create a `DateTime` object from the year, month, and day.
-fromYmd : Int *, Int *, Int * -> DateTime
-fromYmd = \year, month, day -> { date: Date.fromYmd year month day, time: Time.midnight }
+from_ymd : Int *, Int *, Int * -> DateTime
+from_ymd = \year, month, day -> { date: Date.from_ymd year month day, time: Time.midnight }
 
 ## Create a `DateTime` object from the year, week, and day of the week.
-fromYwd : Int *, Int *, Int * -> DateTime
-fromYwd = \year, week, day -> { date: Date.fromYwd year week day, time: Time.midnight }
+from_ywd : Int *, Int *, Int * -> DateTime
+from_ywd = \year, week, day -> { date: Date.from_ywd year week day, time: Time.midnight }
 
 ## Create a `DateTime` object from the year and week.
-fromYw : Int *, Int * -> DateTime
-fromYw = \year, week -> { date: Date.fromYw year week, time: Time.midnight }
+from_yw : Int *, Int * -> DateTime
+from_yw = \year, week -> { date: Date.from_yw year week, time: Time.midnight }
 
 ## Create a `DateTime` object from the year, month, day, hour, minute, and second.
-fromYmdhms : Int *, Int *, Int *, Int *, Int *, Int * -> DateTime
-fromYmdhms = \year, month, day, hour, minute, second ->
-    { date: Date.fromYmd year month day, time: Time.fromHms hour minute second }
+from_ymdhms : Int *, Int *, Int *, Int *, Int *, Int * -> DateTime
+from_ymdhms = \year, month, day, hour, minute, second ->
+    { date: Date.from_ymd year month day, time: Time.from_hms hour minute second }
 
 ## Create a `DateTime` object from the year, month, day, hour, minute, second, and nanosecond.
-fromYmdhmsn : Int *, Int *, Int *, Int *, Int *, Int *, Int * -> DateTime
-fromYmdhmsn = \year, month, day, hour, minute, second, nanosecond ->
-    { date: Date.fromYmd year month day, time: Time.fromHmsn hour minute second nanosecond }
+from_ymdhmsn : Int *, Int *, Int *, Int *, Int *, Int *, Int * -> DateTime
+from_ymdhmsn = \year, month, day, hour, minute, second, nanosecond ->
+    { date: Date.from_ymd year month day, time: Time.from_hmsn hour minute second nanosecond }
 
 ## Convert a `DateTime` object to the number of nanoseconds since the Unix epoch.
-toNanosSinceEpoch : DateTime -> I128
-toNanosSinceEpoch = \dateTime ->
-    dateNanos = Date.toNanosSinceEpoch dateTime.date
-    timeNanos = Time.toNanosSinceMidnight dateTime.time |> Num.toI128
-    dateNanos + timeNanos
+to_nanos_since_epoch : DateTime -> I128
+to_nanos_since_epoch = \date_time ->
+    date_nanos = Date.to_nanos_since_epoch date_time.date
+    time_nanos = Time.to_nanos_since_midnight date_time.time |> Num.toI128
+    date_nanos + time_nanos
 
 ## Convert the number of nanoseconds since the Unix epoch to a `DateTime` object.
-fromNanosSinceEpoch : Int * -> DateTime
-fromNanosSinceEpoch = \nanos ->
-    timeNanos = (
-        if nanos < 0 && Num.toI128 nanos % Const.nanosPerDay != 0 then
-            nanos % Const.nanosPerDay + Const.nanosPerDay
+from_nanos_since_epoch : Int * -> DateTime
+from_nanos_since_epoch = \nanos ->
+    time_nanos = (
+        if nanos < 0 && Num.toI128 nanos % Const.nanos_per_day != 0 then
+            nanos % Const.nanos_per_day + Const.nanos_per_day
         else
-            nanos % Const.nanosPerDay
+            nanos % Const.nanos_per_day
     )
-    dateNanos = nanos - timeNanos
-    date = dateNanos |> Date.fromNanosSinceEpoch
-    time = timeNanos |> Num.toI64 |> Time.fromNanosSinceMidnight
+    date_nanos = nanos - time_nanos
+    date = date_nanos |> Date.from_nanos_since_epoch
+    time = time_nanos |> Num.toI64 |> Time.from_nanos_since_midnight
     { date, time }
 
 ## Add nanoseconds to a `DateTime` object.
-addNanoseconds : DateTime, Int * -> DateTime
-addNanoseconds = \dateTime, nanos ->
-    timeNanos = Time.toNanosSinceMidnight dateTime.time + Num.toI64 nanos
+add_nanoseconds : DateTime, Int * -> DateTime
+add_nanoseconds = \date_time, nanos ->
+    time_nanos = Time.to_nanos_since_midnight date_time.time + Num.toI64 nanos
     days = (
-        if timeNanos >= 0 then
-            timeNanos // Const.nanosPerDay |> Num.toI64
+        if time_nanos >= 0 then
+            time_nanos // Const.nanos_per_day |> Num.toI64
         else
-            timeNanos
-            // Const.nanosPerDay
+            time_nanos
+            // Const.nanos_per_day
             |> Num.add
                 (
-                    if timeNanos % Const.nanosPerDay < 0 then
+                    if time_nanos % Const.nanos_per_day < 0 then
                         -1
                     else
                         0
                 )
             |> Num.toI64
     )
-    { date: Date.addDays dateTime.date days, time: Time.fromNanosSinceMidnight timeNanos |> Time.normalize }
+    { date: Date.add_days date_time.date days, time: Time.from_nanos_since_midnight time_nanos |> Time.normalize }
 
 ## Add seconds to a `DateTime` object.
-addSeconds : DateTime, Int * -> DateTime
-addSeconds = \dateTime, seconds -> addNanoseconds dateTime (Num.toI64 seconds * Const.nanosPerSecond)
+add_seconds : DateTime, Int * -> DateTime
+add_seconds = \date_time, seconds -> add_nanoseconds date_time (Num.toI64 seconds * Const.nanos_per_second)
 
 ## Add minutes to a `DateTime` object.
-addMinutes : DateTime, Int * -> DateTime
-addMinutes = \dateTime, minutes -> addNanoseconds dateTime (Num.toI64 minutes * Const.nanosPerMinute)
+add_minutes : DateTime, Int * -> DateTime
+add_minutes = \date_time, minutes -> add_nanoseconds date_time (Num.toI64 minutes * Const.nanos_per_minute)
 
 ## Add hours to a `DateTime` object.
-addHours : DateTime, Int * -> DateTime
-addHours = \dateTime, hours -> addNanoseconds dateTime (Num.toI64 hours * Const.nanosPerHour)
+add_hours : DateTime, Int * -> DateTime
+add_hours = \date_time, hours -> add_nanoseconds date_time (Num.toI64 hours * Const.nanos_per_hour)
 
 ## Add days to a `DateTime` object.
-addDays : DateTime, Int * -> DateTime
-addDays = \dateTime, days -> { date: Date.addDays dateTime.date days, time: dateTime.time }
+add_days : DateTime, Int * -> DateTime
+add_days = \date_time, days -> { date: Date.add_days date_time.date days, time: date_time.time }
 
 ## Add months to a `DateTime` object.
-addMonths : DateTime, Int * -> DateTime
-addMonths = \dateTime, months -> { date: Date.addMonths dateTime.date months, time: dateTime.time }
+add_months : DateTime, Int * -> DateTime
+add_months = \date_time, months -> { date: Date.add_months date_time.date months, time: date_time.time }
 
 ## Add years to a `DateTime` object.
-addYears : DateTime, Int * -> DateTime
-addYears = \dateTime, years -> { date: Date.addYears dateTime.date years, time: dateTime.time }
+add_years : DateTime, Int * -> DateTime
+add_years = \date_time, years -> { date: Date.add_years date_time.date years, time: date_time.time }
 
 ## Add a `Duration` object to a `DateTime` object.
-addDurationAndDateTime : Duration, DateTime -> DateTime
-addDurationAndDateTime = \duration, dateTime ->
-    durationNanos = Duration.toNanoseconds duration
-    dateNanos = Date.toNanosSinceEpoch dateTime.date |> Num.toI128
-    timeNanos = Time.toNanosSinceMidnight dateTime.time |> Num.toI128
-    durationNanos + dateNanos + timeNanos |> fromNanosSinceEpoch
+add_duration_and_date_time : Duration, DateTime -> DateTime
+add_duration_and_date_time = \duration, date_time ->
+    duration_nanos = Duration.to_nanoseconds duration
+    date_nanos = Date.to_nanos_since_epoch date_time.date |> Num.toI128
+    time_nanos = Time.to_nanos_since_midnight date_time.time |> Num.toI128
+    duration_nanos + date_nanos + time_nanos |> from_nanos_since_epoch
 
 ## Add a `DateTime` object and a `Duration` object.
-addDateTimeAndDuration : DateTime, Duration -> DateTime
-addDateTimeAndDuration = \dateTime, duration -> addDurationAndDateTime duration dateTime
+add_date_time_and_duration : DateTime, Duration -> DateTime
+add_date_time_and_duration = \date_time, duration -> add_duration_and_date_time duration date_time
 
 ## Convert a `DateTime` object to an ISO 8601 string.
-toIsoStr : DateTime -> Str
-toIsoStr = \dateTime ->
-    Date.toIsoStr dateTime.date |> Str.concat "T" |> Str.concat (Time.toIsoStr dateTime.time)
+to_iso_str : DateTime -> Str
+to_iso_str = \date_time ->
+    Date.to_iso_str date_time.date |> Str.concat "T" |> Str.concat (Time.to_iso_str date_time.time)
 
 ## Convert a `DateTime` object to an ISO 8601 list of UTF-8 bytes.
-toIsoU8 : DateTime -> List U8
-toIsoU8 = \dateTime ->
-    Date.toIsoU8 dateTime.date |> List.concat ['T'] |> List.concat (Time.toIsoU8 dateTime.time)
+to_iso_u8 : DateTime -> List U8
+to_iso_u8 = \date_time ->
+    Date.to_iso_u8 date_time.date |> List.concat ['T'] |> List.concat (Time.to_iso_u8 date_time.time)
 
 ## Convert an ISO 8601 string to a `DateTime` object.
-fromIsoStr : Str -> Result DateTime [InvalidDateTimeFormat]
-fromIsoStr = \str -> Str.toUtf8 str |> fromIsoU8
+from_iso_str : Str -> Result DateTime [InvalidDateTimeFormat]
+from_iso_str = \str -> Str.toUtf8 str |> from_iso_u8
 
 ## Convert an ISO 8601 list of UTF-8 bytes to a `DateTime` object.
-fromIsoU8 : List U8 -> Result DateTime [InvalidDateTimeFormat]
-fromIsoU8 = \bytes ->
-    when splitUtf8AndKeepDelimiters bytes ['T'] is
-        [dateBytes, ['T'], timeBytes] ->
+from_iso_u8 : List U8 -> Result DateTime [InvalidDateTimeFormat]
+from_iso_u8 = \bytes ->
+    when split_utf8_and_keep_delimiters bytes ['T'] is
+        [date_bytes, ['T'], time_bytes] ->
             # TODO: currently cannot support timezone offsets which exceed or precede the current day
-            when (Date.fromIsoU8 dateBytes, Time.fromIsoU8 timeBytes) is
+            when (Date.from_iso_u8 date_bytes, Time.from_iso_u8 time_bytes) is
                 (Ok date, Ok time) ->
                     { date, time } |> normalize |> Ok
 
                 (_, _) -> Err InvalidDateTimeFormat
 
-        [dateBytes] ->
-            when Date.fromIsoU8 dateBytes is
-                Ok date -> { date, time: Time.fromHms 0 0 0 } |> Ok
+        [date_bytes] ->
+            when Date.from_iso_u8 date_bytes is
+                Ok date -> { date, time: Time.from_hms 0 0 0 } |> Ok
                 Err _ -> Err InvalidDateTimeFormat
 
         _ -> Err InvalidDateTimeFormat
 
 # <==== TESTS ====>
 # <---- toIsoStr ---->
-expect toIsoStr unixEpoch == "1970-01-01T00:00:00"
-expect toIsoStr (fromYmdhmsn 1970 1 1 0 0 0 (Const.nanosPerSecond // 2)) == "1970-01-01T00:00:00,5"
+expect to_iso_str unix_epoch == "1970-01-01T00:00:00"
+expect to_iso_str (from_ymdhmsn 1970 1 1 0 0 0 (Const.nanos_per_second // 2)) == "1970-01-01T00:00:00,5"
 
 # <---- toIsoU8 ---->
-expect toIsoU8 unixEpoch == Str.toUtf8 "1970-01-01T00:00:00"
+expect to_iso_u8 unix_epoch == Str.toUtf8 "1970-01-01T00:00:00"
 
 # <---- addNanoseconds ---->
-expect addNanoseconds (fromYmdhmsn 1970 1 1 0 0 0 0) 1 == fromYmdhmsn 1970 1 1 0 0 0 1
-expect addNanoseconds (fromYmdhmsn 1970 1 1 0 0 0 0) Const.nanosPerSecond == fromYmdhmsn 1970 1 1 0 0 1 0
-expect addNanoseconds (fromYmdhmsn 1970 1 1 0 0 0 0) Const.nanosPerDay == fromYmdhmsn 1970 1 2 0 0 0 0
-expect addNanoseconds (fromYmdhmsn 1970 1 1 0 0 0 0) -1 == fromYmdhmsn 1969 12 31 23 59 59 (Const.nanosPerSecond - 1)
-expect addNanoseconds (fromYmdhmsn 1970 1 1 0 0 0 0) -Const.nanosPerDay == fromYmdhmsn 1969 12 31 0 0 0 0
-expect addNanoseconds (fromYmdhmsn 1970 1 1 0 0 0 0) (-Const.nanosPerDay - 1) == fromYmdhmsn 1969 12 30 23 59 59 (Const.nanosPerSecond - 1)
+expect add_nanoseconds (from_ymdhmsn 1970 1 1 0 0 0 0) 1 == from_ymdhmsn 1970 1 1 0 0 0 1
+expect add_nanoseconds (from_ymdhmsn 1970 1 1 0 0 0 0) Const.nanos_per_second == from_ymdhmsn 1970 1 1 0 0 1 0
+expect add_nanoseconds (from_ymdhmsn 1970 1 1 0 0 0 0) Const.nanos_per_day == from_ymdhmsn 1970 1 2 0 0 0 0
+expect add_nanoseconds (from_ymdhmsn 1970 1 1 0 0 0 0) -1 == from_ymdhmsn 1969 12 31 23 59 59 (Const.nanos_per_second - 1)
+expect add_nanoseconds (from_ymdhmsn 1970 1 1 0 0 0 0) -Const.nanos_per_day == from_ymdhmsn 1969 12 31 0 0 0 0
+expect add_nanoseconds (from_ymdhmsn 1970 1 1 0 0 0 0) ((-Const.nanos_per_day) - 1) == from_ymdhmsn 1969 12 30 23 59 59 (Const.nanos_per_second - 1)
 
 # <---- addDateTimeAndDuration ---->
 expect
-    addDateTimeAndDuration unixEpoch (Duration.fromNanoseconds -1 |> unwrap "will not overflow") == fromYmdhmsn 1969 12 31 23 59 59 (Const.nanosPerSecond - 1)
+    add_date_time_and_duration unix_epoch (Duration.from_nanoseconds -1 |> unwrap "will not overflow") == from_ymdhmsn 1969 12 31 23 59 59 (Const.nanos_per_second - 1)
 expect
-    addDateTimeAndDuration unixEpoch (Duration.fromDays 365 |> unwrap "will not overflow") == fromYmdhmsn 1971 1 1 0 0 0 0
+    add_date_time_and_duration unix_epoch (Duration.from_days 365 |> unwrap "will not overflow") == from_ymdhmsn 1971 1 1 0 0 0 0
 
 # <--- fromNanosSinceEpoch --->
-expect fromNanosSinceEpoch (364 * 24 * Const.nanosPerHour + 12 * Const.nanosPerHour + 34 * Const.nanosPerMinute + 56 * Const.nanosPerSecond + 5) == fromYmdhmsn 1970 12 31 12 34 56 5
-expect fromNanosSinceEpoch (-1) == fromYmdhmsn 1969 12 31 23 59 59 (Const.nanosPerSecond - 1)
+expect from_nanos_since_epoch (364 * 24 * Const.nanos_per_hour + 12 * Const.nanos_per_hour + 34 * Const.nanos_per_minute + 56 * Const.nanos_per_second + 5) == from_ymdhmsn 1970 12 31 12 34 56 5
+expect from_nanos_since_epoch (-1) == from_ymdhmsn 1969 12 31 23 59 59 (Const.nanos_per_second - 1)
 
 # <--- toNanosSinceEpoch --->
-expect toNanosSinceEpoch (fromYmdhmsn 1970 12 31 12 34 56 5) == 364 * Const.nanosPerDay + 12 * Const.nanosPerHour + 34 * Const.nanosPerMinute + 56 * Const.nanosPerSecond + 5
+expect to_nanos_since_epoch (from_ymdhmsn 1970 12 31 12 34 56 5) == 364 * Const.nanos_per_day + 12 * Const.nanos_per_hour + 34 * Const.nanos_per_minute + 56 * Const.nanos_per_second + 5

--- a/package/Duration.roc
+++ b/package/Duration.roc
@@ -1,117 +1,117 @@
 ## The duration modules provides the `Duration` type and associated functions for representing time durations and performing date/time arithmetic.
 module [
-    addDurations,
+    add_durations,
     Duration,
-    fromDays,
-    fromHours,
-    fromMinutes,
-    fromNanoseconds,
-    fromSeconds,
-    toDays,
-    toHours,
-    toMinutes,
-    toNanoseconds,
-    toSeconds,
+    from_days,
+    from_hours,
+    from_minutes,
+    from_nanoseconds,
+    from_seconds,
+    to_days,
+    to_hours,
+    to_minutes,
+    to_nanoseconds,
+    to_seconds,
 ]
 
 import Const
 import Unsafe exposing [unwrap] # for unit testing only
 
 ## ```
-## Duration : { 
-##     days : I64, 
-##     hours : I8, 
-##     minutes : I8, 
-##     seconds : I8, 
-##     nanoseconds : I32 
+## Duration : {
+##     days : I64,
+##     hours : I8,
+##     minutes : I8,
+##     seconds : I8,
+##     nanoseconds : I32
 ## }
 ## ```
 Duration : { days : I64, hours : I8, minutes : I8, seconds : I8, nanoseconds : I32 }
 
 ## Create a `Duration` object from nanoseconds.
-fromNanoseconds : Int * -> Result Duration [DurationOverflow]
-fromNanoseconds = \nanos ->
+from_nanoseconds : Int * -> Result Duration [DurationOverflow]
+from_nanoseconds = \nanos ->
     if
-        (nanos // Const.nanosPerDay |> Num.toI128) > (Num.maxI64 |> Num.toI128)
+        (nanos // Const.nanos_per_day |> Num.toI128) > (Num.maxI64 |> Num.toI128)
     then
         Err DurationOverflow
     else
         Ok {
-            days: nanos // (Const.nanosPerDay) |> Num.toI64,
-            hours: (nanos % (Const.nanosPerDay)) // Const.nanosPerHour |> Num.toI8,
-            minutes: (nanos % Const.nanosPerHour) // Const.nanosPerMinute |> Num.toI8,
-            seconds: (nanos % Const.nanosPerMinute) // Const.nanosPerSecond |> Num.toI8,
-            nanoseconds: nanos % Const.nanosPerSecond |> Num.toI32,
+            days: nanos // (Const.nanos_per_day) |> Num.toI64,
+            hours: (nanos % (Const.nanos_per_day)) // Const.nanos_per_hour |> Num.toI8,
+            minutes: (nanos % Const.nanos_per_hour) // Const.nanos_per_minute |> Num.toI8,
+            seconds: (nanos % Const.nanos_per_minute) // Const.nanos_per_second |> Num.toI8,
+            nanoseconds: nanos % Const.nanos_per_second |> Num.toI32,
         }
 
 ## Convert a `Duration` object to nanoseconds.
-toNanoseconds : Duration -> I128
-toNanoseconds = \duration ->
+to_nanoseconds : Duration -> I128
+to_nanoseconds = \duration ->
     (Num.toI128 duration.nanoseconds)
     + (Num.toI128 duration.seconds)
-    * Const.nanosPerSecond
+    * Const.nanos_per_second
     + (Num.toI128 duration.minutes)
-    * Const.nanosPerMinute
+    * Const.nanos_per_minute
     + (Num.toI128 duration.hours)
-    * Const.nanosPerHour
+    * Const.nanos_per_hour
     + (Num.toI128 duration.days)
-    * (Const.nanosPerHour * 24)
+    * (Const.nanos_per_hour * 24)
 
 ## Create a `Duration` object from seconds.
-fromSeconds : Int * -> Result Duration [DurationOverflow]
-fromSeconds = \seconds ->
+from_seconds : Int * -> Result Duration [DurationOverflow]
+from_seconds = \seconds ->
     if
-        (seconds // Const.secondsPerDay |> Num.toI128) > (Num.maxI64 |> Num.toI128)
+        (seconds // Const.seconds_per_day |> Num.toI128) > (Num.maxI64 |> Num.toI128)
     then
         Err DurationOverflow
     else
         Ok {
-            days: seconds // (Const.secondsPerDay) |> Num.toI64,
-            hours: (seconds % (Const.secondsPerDay)) // Const.secondsPerHour |> Num.toI8,
-            minutes: (seconds % Const.secondsPerHour) // Const.secondsPerMinute |> Num.toI8,
-            seconds: seconds % Const.secondsPerMinute |> Num.toI8,
+            days: seconds // (Const.seconds_per_day) |> Num.toI64,
+            hours: (seconds % (Const.seconds_per_day)) // Const.seconds_per_hour |> Num.toI8,
+            minutes: (seconds % Const.seconds_per_hour) // Const.seconds_per_minute |> Num.toI8,
+            seconds: seconds % Const.seconds_per_minute |> Num.toI8,
             nanoseconds: 0,
         }
 
 ## Convert a `Duration` object to seconds (truncates nanoseconds).
-toSeconds : Duration -> I128
-toSeconds = \duration ->
+to_seconds : Duration -> I128
+to_seconds = \duration ->
     (Num.toI128 duration.seconds)
     + (Num.toI128 duration.minutes)
-    * Const.secondsPerMinute
+    * Const.seconds_per_minute
     + (Num.toI128 duration.hours)
-    * Const.secondsPerHour
+    * Const.seconds_per_hour
     + (Num.toI128 duration.days)
-    * (Const.secondsPerHour * 24)
+    * (Const.seconds_per_hour * 24)
 
 ## Create a `Duration` object from minutes.
-fromMinutes : Int * -> Result Duration [DurationOverflow]
-fromMinutes = \minutes ->
+from_minutes : Int * -> Result Duration [DurationOverflow]
+from_minutes = \minutes ->
     if
-        (minutes // Const.minutesPerDay |> Num.toI128) > (Num.maxI64 |> Num.toI128)
+        (minutes // Const.minutes_per_day |> Num.toI128) > (Num.maxI64 |> Num.toI128)
     then
         Err DurationOverflow
     else
         Ok {
-            days: minutes // (Const.minutesPerDay) |> Num.toI64,
-            hours: (minutes % (Const.minutesPerDay)) // Const.minutesPerHour |> Num.toI8,
-            minutes: minutes % Const.minutesPerHour |> Num.toI8,
+            days: minutes // (Const.minutes_per_day) |> Num.toI64,
+            hours: (minutes % (Const.minutes_per_day)) // Const.minutes_per_hour |> Num.toI8,
+            minutes: minutes % Const.minutes_per_hour |> Num.toI8,
             seconds: 0,
             nanoseconds: 0,
         }
 
 ## Convert a `Duration` object to minutes (truncates seconds and lower).
-toMinutes : Duration -> I128
-toMinutes = \duration ->
+to_minutes : Duration -> I128
+to_minutes = \duration ->
     (Num.toI128 duration.minutes)
     + (Num.toI128 duration.hours)
-    * Const.minutesPerHour
+    * Const.minutes_per_hour
     + (Num.toI128 duration.days)
-    * (Const.minutesPerHour * 24)
+    * (Const.minutes_per_hour * 24)
 
 ## Create a `Duration` object from hours.
-fromHours : Int * -> Result Duration [DurationOverflow]
-fromHours = \hours ->
+from_hours : Int * -> Result Duration [DurationOverflow]
+from_hours = \hours ->
     if
         (hours // 24 |> Num.toI128) > (Num.maxI64 |> Num.toI128)
     then
@@ -126,15 +126,15 @@ fromHours = \hours ->
         }
 
 ## Convert a `Duration` object to hours (truncates minutes and lower).
-toHours : Duration -> I128
-toHours = \duration ->
+to_hours : Duration -> I128
+to_hours = \duration ->
     (Num.toI128 duration.hours)
     + (Num.toI128 duration.days)
     * 24
 
 ## Create a `Duration` object from days.
-fromDays : Int * -> Result Duration [DurationOverflow]
-fromDays = \days ->
+from_days : Int * -> Result Duration [DurationOverflow]
+from_days = \days ->
     if
         days |> Num.toI128 > Num.maxI64 |> Num.toI128
     then
@@ -149,34 +149,34 @@ fromDays = \days ->
         }
 
 ## Convert a `Duration` object to days (truncates hours and lower).
-toDays : Duration -> I64
-toDays = \duration -> duration.days
+to_days : Duration -> I64
+to_days = \duration -> duration.days
 
 ## Add two `Duration` objects.
-addDurations : Duration, Duration -> Result Duration [DurationOverflow]
-addDurations = \d1, d2 ->
-    nanos1 = toNanoseconds d1
-    nanos2 = toNanoseconds d2
-    fromNanoseconds (nanos1 + nanos2)
+add_durations : Duration, Duration -> Result Duration [DurationOverflow]
+add_durations = \d1, d2 ->
+    nanos1 = to_nanoseconds d1
+    nanos2 = to_nanoseconds d2
+    from_nanoseconds (nanos1 + nanos2)
 
 expect
     days = Num.maxI64
-    duration = fromDays days |> unwrap "will not overflow"
-    duration |> toDays == days
+    duration = from_days days |> unwrap "will not overflow"
+    duration |> to_days == days
 
 expect
-    d1 = fromDays (Num.maxI64 // 2) |> unwrap "will not overflow"
-    d2 = fromDays (Num.maxI64 // 2) |> unwrap "will not overflow"
-    d3 = fromDays ((Num.maxI64 // 2) * 2) |> unwrap "will not overflow"
-    addDurations d1 d2 == Ok d3
+    d1 = from_days (Num.maxI64 // 2) |> unwrap "will not overflow"
+    d2 = from_days (Num.maxI64 // 2) |> unwrap "will not overflow"
+    d3 = from_days ((Num.maxI64 // 2) * 2) |> unwrap "will not overflow"
+    add_durations d1 d2 == Ok d3
 
 expect
-    d1 = fromDays Num.minI64 |> unwrap "will not overflow"
-    d2 = fromDays Num.maxI64 |> unwrap "will not overflow"
-    d3 = fromDays -1 |> unwrap "will not overflow"
-    addDurations d1 d2 == Ok d3
+    d1 = from_days Num.minI64 |> unwrap "will not overflow"
+    d2 = from_days Num.maxI64 |> unwrap "will not overflow"
+    d3 = from_days -1 |> unwrap "will not overflow"
+    add_durations d1 d2 == Ok d3
 
 expect
-    duration = fromDays Num.maxI64 |> unwrap "will not overflow"
-    addDurations duration duration == Err DurationOverflow
+    duration = from_days Num.maxI64 |> unwrap "will not overflow"
+    add_durations duration duration == Err DurationOverflow
 

--- a/package/Tests.roc
+++ b/package/Tests.roc
@@ -1,22 +1,22 @@
 module []
 
 import Const exposing [
-    nanosPerDay,
-    nanosPerHour,
-    nanosPerMinute,
-    nanosPerSecond,
-    secondsPerDay,
+    nanos_per_day,
+    nanos_per_hour,
+    nanos_per_minute,
+    nanos_per_second,
+    seconds_per_day,
 ]
 import Date
 import DateTime
 import Time
 import Utils exposing [
-    splitListAtIndices,
-    splitUtf8AndKeepDelimiters,
-    utf8ToFrac,
-    utf8ToInt,
-    utf8ToIntSigned,
-    validateUtf8SingleBytes,
+    split_list_at_indices,
+    split_utf8_and_keep_delimiters,
+    utf8_to_frac,
+    utf8_to_int,
+    utf8_to_int_signed,
+    validate_utf8_single_bytes,
 ]
 import Unsafe exposing [unwrap] # for unit testing only
 
@@ -24,462 +24,462 @@ import Unsafe exposing [unwrap] # for unit testing only
 # <---- parseDate ---->
 # parseCalendarDateCentury
 # 1
-expect Date.fromIsoStr "20" == Date.fromYmd 2000 1 1 |> Ok
-expect Date.fromIsoStr "20" |> unwrap "Date.fromIsoStr '20'" |> Date.toNanosSinceEpoch == (10_957) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "20" == Date.from_ymd 2000 1 1 |> Ok
+expect Date.from_iso_str "20" |> unwrap "Date.fromIsoStr '20'" |> Date.to_nanos_since_epoch == (10_957) * seconds_per_day * nanos_per_second
 # 2
-expect Date.fromIsoStr "19" == Date.fromYmd 1900 1 1 |> Ok
-expect Date.fromIsoStr "19" |> unwrap "Date.fromIsoStr '19'" |> Date.toNanosSinceEpoch == -25_567 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "19" == Date.from_ymd 1900 1 1 |> Ok
+expect Date.from_iso_str "19" |> unwrap "Date.fromIsoStr '19'" |> Date.to_nanos_since_epoch == -25_567 * seconds_per_day * nanos_per_second
 # 3
-expect Date.fromIsoStr "ab" == Err InvalidDateFormat
+expect Date.from_iso_str "ab" == Err InvalidDateFormat
 
 # parseCalendarDateYear
 # 4
-expect Date.fromIsoStr "2024" == Date.fromYmd 2024 1 1 |> Ok
-expect Date.fromIsoStr "2024" |> unwrap "Date.fromIsoStr '2024'" |> Date.toNanosSinceEpoch == (19_723) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "2024" == Date.from_ymd 2024 1 1 |> Ok
+expect Date.from_iso_str "2024" |> unwrap "Date.fromIsoStr '2024'" |> Date.to_nanos_since_epoch == (19_723) * seconds_per_day * nanos_per_second
 # 5
-expect Date.fromIsoStr "1970" == Date.fromYmd 1970 1 1 |> Ok
-expect Date.fromIsoStr "1970" |> unwrap "Date.fromIsoStr '1970'" |> Date.toNanosSinceEpoch == 0
+expect Date.from_iso_str "1970" == Date.from_ymd 1970 1 1 |> Ok
+expect Date.from_iso_str "1970" |> unwrap "Date.fromIsoStr '1970'" |> Date.to_nanos_since_epoch == 0
 # 6
-expect Date.fromIsoStr "1968" == Date.fromYmd 1968 1 1 |> Ok
-expect Date.fromIsoStr "1968" |> unwrap "Date.fromIsoStr '1968'" |> Date.toNanosSinceEpoch == -731 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1968" == Date.from_ymd 1968 1 1 |> Ok
+expect Date.from_iso_str "1968" |> unwrap "Date.fromIsoStr '1968'" |> Date.to_nanos_since_epoch == -731 * seconds_per_day * nanos_per_second
 # 7
-expect Date.fromIsoStr "202f" == Err InvalidDateFormat
+expect Date.from_iso_str "202f" == Err InvalidDateFormat
 
 # parseWeekDateReducedBasic
 # 8
-expect Date.fromIsoStr "2024W04" == Date.fromYmd 2024 1 22 |> Ok
-expect Date.fromIsoStr "2024W04" |> unwrap "Date.fromIsoStr '2024W04'" |> Date.toNanosSinceEpoch == (19_723 + 21) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "2024W04" == Date.from_ymd 2024 1 22 |> Ok
+expect Date.from_iso_str "2024W04" |> unwrap "Date.fromIsoStr '2024W04'" |> Date.to_nanos_since_epoch == (19_723 + 21) * seconds_per_day * nanos_per_second
 # 9
-expect Date.fromIsoStr "1970W01" == Date.fromYmd 1970 1 1 |> Ok
-expect Date.fromIsoStr "1970W01" |> unwrap "Date.fromIsoStr '1970W01'" |> Date.toNanosSinceEpoch == 0
+expect Date.from_iso_str "1970W01" == Date.from_ymd 1970 1 1 |> Ok
+expect Date.from_iso_str "1970W01" |> unwrap "Date.fromIsoStr '1970W01'" |> Date.to_nanos_since_epoch == 0
 # 10
-expect Date.fromIsoStr "1968W01" == Date.fromYmd 1968 1 1 |> Ok
-expect Date.fromIsoStr "1968W01" |> unwrap "Date.fromIsoStr '1968W01'" |> Date.toNanosSinceEpoch == -731 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1968W01" == Date.from_ymd 1968 1 1 |> Ok
+expect Date.from_iso_str "1968W01" |> unwrap "Date.fromIsoStr '1968W01'" |> Date.to_nanos_since_epoch == -731 * seconds_per_day * nanos_per_second
 # 11
-expect Date.fromIsoStr "2024W53" == Err InvalidDateFormat
+expect Date.from_iso_str "2024W53" == Err InvalidDateFormat
 # 12
-expect Date.fromIsoStr "2024W00" == Err InvalidDateFormat
+expect Date.from_iso_str "2024W00" == Err InvalidDateFormat
 # 13
-expect Date.fromIsoStr "2024Www" == Err InvalidDateFormat
+expect Date.from_iso_str "2024Www" == Err InvalidDateFormat
 
 # parseCalendarDateMonth
 # 14
-expect Date.fromIsoStr "2024-02" == Date.fromYmd 2024 2 1 |> Ok
-expect Date.fromIsoStr "2024-02" |> unwrap "Date.fromIsoStr '2024-02'" |> Date.toNanosSinceEpoch == (19_723 + 31) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "2024-02" == Date.from_ymd 2024 2 1 |> Ok
+expect Date.from_iso_str "2024-02" |> unwrap "Date.fromIsoStr '2024-02'" |> Date.to_nanos_since_epoch == (19_723 + 31) * seconds_per_day * nanos_per_second
 # 15
-expect Date.fromIsoStr "1970-01" == Date.fromYmd 1970 1 1 |> Ok
-expect Date.fromIsoStr "1970-01" |> unwrap "Date.fromIsoStr '1970-01'" |> Date.toNanosSinceEpoch == 0
+expect Date.from_iso_str "1970-01" == Date.from_ymd 1970 1 1 |> Ok
+expect Date.from_iso_str "1970-01" |> unwrap "Date.fromIsoStr '1970-01'" |> Date.to_nanos_since_epoch == 0
 # 16
-expect Date.fromIsoStr "1968-01" == Date.fromYmd 1968 1 1 |> Ok
-expect Date.fromIsoStr "1968-01" |> unwrap "Date.fromIsoStr '1968-01'" |> Date.toNanosSinceEpoch == -731 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1968-01" == Date.from_ymd 1968 1 1 |> Ok
+expect Date.from_iso_str "1968-01" |> unwrap "Date.fromIsoStr '1968-01'" |> Date.to_nanos_since_epoch == -731 * seconds_per_day * nanos_per_second
 # 17
-expect Date.fromIsoStr "2024-13" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-13" == Err InvalidDateFormat
 # 18
-expect Date.fromIsoStr "2024-00" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-00" == Err InvalidDateFormat
 # 19
-expect Date.fromIsoStr "2024-0a" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-0a" == Err InvalidDateFormat
 
 # parseOrdinalDateBasic
 # 20
-expect Date.fromIsoStr "2024023" == Date.fromYmd 2024 1 23 |> Ok
-expect Date.fromIsoStr "2024023" |> unwrap "Date.fromIsoStr '2024023'" |> Date.toNanosSinceEpoch == (19_723 + 22) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "2024023" == Date.from_ymd 2024 1 23 |> Ok
+expect Date.from_iso_str "2024023" |> unwrap "Date.fromIsoStr '2024023'" |> Date.to_nanos_since_epoch == (19_723 + 22) * seconds_per_day * nanos_per_second
 # 21
-expect Date.fromIsoStr "1970001" == Date.fromYmd 1970 1 1 |> Ok
-expect Date.fromIsoStr "1970001" |> unwrap "Date.fromIsoStr '1970001'" |> Date.toNanosSinceEpoch == 0
+expect Date.from_iso_str "1970001" == Date.from_ymd 1970 1 1 |> Ok
+expect Date.from_iso_str "1970001" |> unwrap "Date.fromIsoStr '1970001'" |> Date.to_nanos_since_epoch == 0
 # 22
-expect Date.fromIsoStr "1968001" == Date.fromYmd 1968 1 1 |> Ok
-expect Date.fromIsoStr "1968001" |> unwrap "Date.fromIsoStr '1968001'" |> Date.toNanosSinceEpoch == -731 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1968001" == Date.from_ymd 1968 1 1 |> Ok
+expect Date.from_iso_str "1968001" |> unwrap "Date.fromIsoStr '1968001'" |> Date.to_nanos_since_epoch == -731 * seconds_per_day * nanos_per_second
 # 23
-expect Date.fromIsoStr "2024000" == Err InvalidDateFormat
+expect Date.from_iso_str "2024000" == Err InvalidDateFormat
 # 24
-expect Date.fromIsoStr "2024367" == Err InvalidDateFormat
+expect Date.from_iso_str "2024367" == Err InvalidDateFormat
 # 25
-expect Date.fromIsoStr "2024a23" == Err InvalidDateFormat
+expect Date.from_iso_str "2024a23" == Err InvalidDateFormat
 
 # parseWeekDateReducedExtended
 # 26
-expect Date.fromIsoStr "2024-W04" == Date.fromYmd 2024 1 22 |> Ok
-expect Date.fromIsoStr "2024-W04" |> unwrap "Date.fromIsoStr '2024-W04'" |> Date.toNanosSinceEpoch == (19_723 + 21) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "2024-W04" == Date.from_ymd 2024 1 22 |> Ok
+expect Date.from_iso_str "2024-W04" |> unwrap "Date.fromIsoStr '2024-W04'" |> Date.to_nanos_since_epoch == (19_723 + 21) * seconds_per_day * nanos_per_second
 # 27
-expect Date.fromIsoStr "1970-W01" == Date.fromYmd 1970 1 1 |> Ok
-expect Date.fromIsoStr "1970-W01" |> unwrap "Date.fromIsoStr '1970-W01'" |> Date.toNanosSinceEpoch == 0
+expect Date.from_iso_str "1970-W01" == Date.from_ymd 1970 1 1 |> Ok
+expect Date.from_iso_str "1970-W01" |> unwrap "Date.fromIsoStr '1970-W01'" |> Date.to_nanos_since_epoch == 0
 # 28
-expect Date.fromIsoStr "1968-W01" == Date.fromYmd 1968 1 1 |> Ok
-expect Date.fromIsoStr "1968-W01" |> unwrap "Date.fromIsoStr '1968-W01'" |> Date.toNanosSinceEpoch == -731 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1968-W01" == Date.from_ymd 1968 1 1 |> Ok
+expect Date.from_iso_str "1968-W01" |> unwrap "Date.fromIsoStr '1968-W01'" |> Date.to_nanos_since_epoch == -731 * seconds_per_day * nanos_per_second
 # 29
-expect Date.fromIsoStr "2024-W53" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-W53" == Err InvalidDateFormat
 # 30
-expect Date.fromIsoStr "2024-W00" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-W00" == Err InvalidDateFormat
 # 31
-expect Date.fromIsoStr "2024-Ww1" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-Ww1" == Err InvalidDateFormat
 
 # parseWeekDateBasic
 # 32
-expect Date.fromIsoStr "2024W042" == Date.fromYmd 2024 1 23 |> Ok
-expect Date.fromIsoStr "2024W042" |> unwrap "Date.fromIsoStr '2024W042'" |> Date.toNanosSinceEpoch == (19_723 + 22) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "2024W042" == Date.from_ymd 2024 1 23 |> Ok
+expect Date.from_iso_str "2024W042" |> unwrap "Date.fromIsoStr '2024W042'" |> Date.to_nanos_since_epoch == (19_723 + 22) * seconds_per_day * nanos_per_second
 # 33
-expect Date.fromIsoStr "1970W011" == Date.fromYmd 1970 1 1 |> Ok
-expect Date.fromIsoStr "1970W011" |> unwrap "Date.fromIsoStr '1970W011'" |> Date.toNanosSinceEpoch == 0
+expect Date.from_iso_str "1970W011" == Date.from_ymd 1970 1 1 |> Ok
+expect Date.from_iso_str "1970W011" |> unwrap "Date.fromIsoStr '1970W011'" |> Date.to_nanos_since_epoch == 0
 # 34
-expect Date.fromIsoStr "1970W524" == Date.fromYmd 1970 12 31 |> Ok
-expect Date.fromIsoStr "1970W524" |> unwrap "Date.fromIsoStr '1970W524'" |> Date.toNanosSinceEpoch == 364 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1970W524" == Date.from_ymd 1970 12 31 |> Ok
+expect Date.from_iso_str "1970W524" |> unwrap "Date.fromIsoStr '1970W524'" |> Date.to_nanos_since_epoch == 364 * seconds_per_day * nanos_per_second
 # 35
-expect Date.fromIsoStr "1970W525" == Date.fromYmd 1971 1 1 |> Ok
-expect Date.fromIsoStr "1970W525" |> unwrap "Date.fromIsoStr '1970W525'" |> Date.toNanosSinceEpoch == 365 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1970W525" == Date.from_ymd 1971 1 1 |> Ok
+expect Date.from_iso_str "1970W525" |> unwrap "Date.fromIsoStr '1970W525'" |> Date.to_nanos_since_epoch == 365 * seconds_per_day * nanos_per_second
 # 36
-expect Date.fromIsoStr "1968W011" == Date.fromYmd 1968 1 1 |> Ok
-expect Date.fromIsoStr "1968W011" |> unwrap "Date.fromIsoStr '1968W011'" |> Date.toNanosSinceEpoch == -731 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1968W011" == Date.from_ymd 1968 1 1 |> Ok
+expect Date.from_iso_str "1968W011" |> unwrap "Date.fromIsoStr '1968W011'" |> Date.to_nanos_since_epoch == -731 * seconds_per_day * nanos_per_second
 # 37
-expect Date.fromIsoStr "2024W001" == Err InvalidDateFormat
+expect Date.from_iso_str "2024W001" == Err InvalidDateFormat
 # 38
-expect Date.fromIsoStr "2024W531" == Err InvalidDateFormat
+expect Date.from_iso_str "2024W531" == Err InvalidDateFormat
 # 39
-expect Date.fromIsoStr "2024W010" == Err InvalidDateFormat
+expect Date.from_iso_str "2024W010" == Err InvalidDateFormat
 # 40
-expect Date.fromIsoStr "2024W018" == Err InvalidDateFormat
+expect Date.from_iso_str "2024W018" == Err InvalidDateFormat
 # 41
-expect Date.fromIsoStr "2024W0a2" == Err InvalidDateFormat
+expect Date.from_iso_str "2024W0a2" == Err InvalidDateFormat
 
 # parseOrdinalDateExtended
 # 42
-expect Date.fromIsoStr "2024-023" == Date.fromYmd 2024 1 23 |> Ok
-expect Date.fromIsoStr "2024-023" |> unwrap "Date.fromIsoStr '2024-023'" |> Date.toNanosSinceEpoch == (19_723 + 22) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "2024-023" == Date.from_ymd 2024 1 23 |> Ok
+expect Date.from_iso_str "2024-023" |> unwrap "Date.fromIsoStr '2024-023'" |> Date.to_nanos_since_epoch == (19_723 + 22) * seconds_per_day * nanos_per_second
 # 43
-expect Date.fromIsoStr "1970-001" == Date.fromYmd 1970 1 1 |> Ok
-expect Date.fromIsoStr "1970-001" |> unwrap "Date.fromIsoStr '1970-001'" |> Date.toNanosSinceEpoch == 0
+expect Date.from_iso_str "1970-001" == Date.from_ymd 1970 1 1 |> Ok
+expect Date.from_iso_str "1970-001" |> unwrap "Date.fromIsoStr '1970-001'" |> Date.to_nanos_since_epoch == 0
 # 44
-expect Date.fromIsoStr "1968-001" == Date.fromYmd 1968 1 1 |> Ok
-expect Date.fromIsoStr "1968-001" |> unwrap "Date.fromIsoStr '1968-001'" |> Date.toNanosSinceEpoch == -731 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1968-001" == Date.from_ymd 1968 1 1 |> Ok
+expect Date.from_iso_str "1968-001" |> unwrap "Date.fromIsoStr '1968-001'" |> Date.to_nanos_since_epoch == -731 * seconds_per_day * nanos_per_second
 # 45
-expect Date.fromIsoStr "2024-000" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-000" == Err InvalidDateFormat
 # 46
-expect Date.fromIsoStr "2024-367" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-367" == Err InvalidDateFormat
 # 47
-expect Date.fromIsoStr "2024-0a3" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-0a3" == Err InvalidDateFormat
 
 # parseCalendarDateBasic
 # 48
-expect Date.fromIsoStr "20240123" == Date.fromYmd 2024 1 23 |> Ok
-expect Date.fromIsoStr "20240123" |> unwrap "Date.fromIsoStr '20240123'" |> Date.toNanosSinceEpoch == (19_723 + 22) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "20240123" == Date.from_ymd 2024 1 23 |> Ok
+expect Date.from_iso_str "20240123" |> unwrap "Date.fromIsoStr '20240123'" |> Date.to_nanos_since_epoch == (19_723 + 22) * seconds_per_day * nanos_per_second
 # 49
-expect Date.fromIsoStr "19700101" == Date.fromYmd 1970 1 1 |> Ok
-expect Date.fromIsoStr "19700101" |> unwrap "Date.fromIsoStr '19700101'" |> Date.toNanosSinceEpoch == 0
+expect Date.from_iso_str "19700101" == Date.from_ymd 1970 1 1 |> Ok
+expect Date.from_iso_str "19700101" |> unwrap "Date.fromIsoStr '19700101'" |> Date.to_nanos_since_epoch == 0
 # 50
-expect Date.fromIsoStr "19680101" == Date.fromYmd 1968 1 1 |> Ok
-expect Date.fromIsoStr "19680101" |> unwrap "Date.fromIsoStr '19680101'" |> Date.toNanosSinceEpoch == -731 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "19680101" == Date.from_ymd 1968 1 1 |> Ok
+expect Date.from_iso_str "19680101" |> unwrap "Date.fromIsoStr '19680101'" |> Date.to_nanos_since_epoch == -731 * seconds_per_day * nanos_per_second
 # 51
-expect Date.fromIsoStr "20240100" == Err InvalidDateFormat
+expect Date.from_iso_str "20240100" == Err InvalidDateFormat
 # 52
-expect Date.fromIsoStr "20240132" == Err InvalidDateFormat
+expect Date.from_iso_str "20240132" == Err InvalidDateFormat
 # 53
-expect Date.fromIsoStr "20240001" == Err InvalidDateFormat
+expect Date.from_iso_str "20240001" == Err InvalidDateFormat
 # 54
-expect Date.fromIsoStr "20241301" == Err InvalidDateFormat
+expect Date.from_iso_str "20241301" == Err InvalidDateFormat
 # 55
-expect Date.fromIsoStr "2024a123" == Err InvalidDateFormat
+expect Date.from_iso_str "2024a123" == Err InvalidDateFormat
 
 # parseWeekDateExtended
 # 56
-expect Date.fromIsoStr "2024-W04-2" == Date.fromYmd 2024 1 23 |> Ok
-expect Date.fromIsoStr "2024-W04-2" |> unwrap "Date.fromIsoStr '2024-W04-2'" |> Date.toNanosSinceEpoch == (19_723 + 22) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "2024-W04-2" == Date.from_ymd 2024 1 23 |> Ok
+expect Date.from_iso_str "2024-W04-2" |> unwrap "Date.fromIsoStr '2024-W04-2'" |> Date.to_nanos_since_epoch == (19_723 + 22) * seconds_per_day * nanos_per_second
 # 57
-expect Date.fromIsoStr "1970-W01-1" == Date.fromYmd 1970 1 1 |> Ok
-expect Date.fromIsoStr "1970-W01-1" |> unwrap "Date.fromIsoStr '1970-W01-1'" |> Date.toNanosSinceEpoch == 0
+expect Date.from_iso_str "1970-W01-1" == Date.from_ymd 1970 1 1 |> Ok
+expect Date.from_iso_str "1970-W01-1" |> unwrap "Date.fromIsoStr '1970-W01-1'" |> Date.to_nanos_since_epoch == 0
 # 58
-expect Date.fromIsoStr "1968-W01-1" == Date.fromYmd 1968 1 1 |> Ok
-expect Date.fromIsoStr "1968-W01-1" |> unwrap "Date.fromIsoStr '1968-W01-1'" |> Date.toNanosSinceEpoch == -731 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1968-W01-1" == Date.from_ymd 1968 1 1 |> Ok
+expect Date.from_iso_str "1968-W01-1" |> unwrap "Date.fromIsoStr '1968-W01-1'" |> Date.to_nanos_since_epoch == -731 * seconds_per_day * nanos_per_second
 # 59
-expect Date.fromIsoStr "2024-W53-1" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-W53-1" == Err InvalidDateFormat
 # 60
-expect Date.fromIsoStr "2024-W00-1" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-W00-1" == Err InvalidDateFormat
 # 61
-expect Date.fromIsoStr "2024-W01-0" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-W01-0" == Err InvalidDateFormat
 # 62
-expect Date.fromIsoStr "2024-W01-8" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-W01-8" == Err InvalidDateFormat
 # 63
-expect Date.fromIsoStr "2024-Ww1-1" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-Ww1-1" == Err InvalidDateFormat
 
 # parseCalendarDateExtended
 # 64
-expect Date.fromIsoStr "2024-01-23" == Date.fromYmd 2024 1 23 |> Ok
-expect Date.fromIsoStr "2024-01-23" |> unwrap "Date.fromIsoStr '2024-01-23'" |> Date.toNanosSinceEpoch == (19_723 + 22) * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "2024-01-23" == Date.from_ymd 2024 1 23 |> Ok
+expect Date.from_iso_str "2024-01-23" |> unwrap "Date.fromIsoStr '2024-01-23'" |> Date.to_nanos_since_epoch == (19_723 + 22) * seconds_per_day * nanos_per_second
 # 65
-expect Date.fromIsoStr "1970-01-01" == Date.fromYmd 1970 1 1 |> Ok
-expect Date.fromIsoStr "1970-01-01" |> unwrap "Date.fromIsoStr '1970-01-01'" |> Date.toNanosSinceEpoch == 0
+expect Date.from_iso_str "1970-01-01" == Date.from_ymd 1970 1 1 |> Ok
+expect Date.from_iso_str "1970-01-01" |> unwrap "Date.fromIsoStr '1970-01-01'" |> Date.to_nanos_since_epoch == 0
 # 66
-expect Date.fromIsoStr "1968-01-01" == Date.fromYmd 1968 1 1 |> Ok
-expect Date.fromIsoStr "1968-01-01" |> unwrap "Date.fromIsoStr '1968-01-01'" |> Date.toNanosSinceEpoch == -731 * secondsPerDay * nanosPerSecond
+expect Date.from_iso_str "1968-01-01" == Date.from_ymd 1968 1 1 |> Ok
+expect Date.from_iso_str "1968-01-01" |> unwrap "Date.fromIsoStr '1968-01-01'" |> Date.to_nanos_since_epoch == -731 * seconds_per_day * nanos_per_second
 # 67
-expect Date.fromIsoStr "2024-01-00" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-01-00" == Err InvalidDateFormat
 # 68
-expect Date.fromIsoStr "2024-01-32" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-01-32" == Err InvalidDateFormat
 # 69
-expect Date.fromIsoStr "2024-00-01" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-00-01" == Err InvalidDateFormat
 # 70
-expect Date.fromIsoStr "2024-13-01" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-13-01" == Err InvalidDateFormat
 # 71
-expect Date.fromIsoStr "2024-0a-01" == Err InvalidDateFormat
+expect Date.from_iso_str "2024-0a-01" == Err InvalidDateFormat
 
 # <==== Time.roc ====>
 # <---- parseTime ---->
 # parseLocalTimeHour
 # 72
-expect Time.fromIsoStr "11" == Time.fromHms 11 0 0 |> Ok
-expect Time.fromIsoStr "11" |> unwrap "Time.fromIsoStr '11'" |> Time.toNanosSinceMidnight == (11 * nanosPerHour)
+expect Time.from_iso_str "11" == Time.from_hms 11 0 0 |> Ok
+expect Time.from_iso_str "11" |> unwrap "Time.fromIsoStr '11'" |> Time.to_nanos_since_midnight == (11 * nanos_per_hour)
 # 73
-expect Time.fromIsoStr "00Z" == Time.fromHms 0 0 0 |> Ok
-expect Time.fromIsoStr "00Z" |> unwrap "Time.fromIsoStr '00Z'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "00Z" == Time.from_hms 0 0 0 |> Ok
+expect Time.from_iso_str "00Z" |> unwrap "Time.fromIsoStr '00Z'" |> Time.to_nanos_since_midnight == 0
 # 74
-expect Time.fromIsoStr "T00" == Time.fromHms 0 0 0 |> Ok
-expect Time.fromIsoStr "T00" |> unwrap "Time.fromIsoStr 'T00'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "T00" == Time.from_hms 0 0 0 |> Ok
+expect Time.from_iso_str "T00" |> unwrap "Time.fromIsoStr 'T00'" |> Time.to_nanos_since_midnight == 0
 # 75
-expect Time.fromIsoStr "T00Z" == Time.fromHms 0 0 0 |> Ok
-expect Time.fromIsoStr "T00Z" |> unwrap "Time.fromIsoStr 'T00Z'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "T00Z" == Time.from_hms 0 0 0 |> Ok
+expect Time.from_iso_str "T00Z" |> unwrap "Time.fromIsoStr 'T00Z'" |> Time.to_nanos_since_midnight == 0
 # 76
-expect Time.fromIsoStr "T23" == Time.fromHms 23 0 0 |> Ok
-expect Time.fromIsoStr "T23" |> unwrap "Time.fromIsoStr 'T23'" |> Time.toNanosSinceMidnight == (23 * nanosPerHour)
+expect Time.from_iso_str "T23" == Time.from_hms 23 0 0 |> Ok
+expect Time.from_iso_str "T23" |> unwrap "Time.fromIsoStr 'T23'" |> Time.to_nanos_since_midnight == (23 * nanos_per_hour)
 # 77
-expect Time.fromIsoStr "T24" == Time.fromHms 24 0 0 |> Ok
-expect Time.fromIsoStr "T24" |> unwrap "Time.fromIsoStr 'T24'" |> Time.toNanosSinceMidnight == (24 * nanosPerHour)
+expect Time.from_iso_str "T24" == Time.from_hms 24 0 0 |> Ok
+expect Time.from_iso_str "T24" |> unwrap "Time.fromIsoStr 'T24'" |> Time.to_nanos_since_midnight == (24 * nanos_per_hour)
 # 78
-expect Time.fromIsoStr "T25" == Err InvalidTimeFormat
+expect Time.from_iso_str "T25" == Err InvalidTimeFormat
 # 79
-expect Time.fromIsoStr "T0Z" == Err InvalidTimeFormat
+expect Time.from_iso_str "T0Z" == Err InvalidTimeFormat
 
 # parseLocalTimeMinuteBasic
 # 80
-expect Time.fromIsoStr "1111" == Time.fromHms 11 11 0 |> Ok
-expect Time.fromIsoStr "1111" |> unwrap "Time.fromIsoStr '1111'" |> Time.toNanosSinceMidnight == (11 * nanosPerHour + 11 * nanosPerMinute)
+expect Time.from_iso_str "1111" == Time.from_hms 11 11 0 |> Ok
+expect Time.from_iso_str "1111" |> unwrap "Time.fromIsoStr '1111'" |> Time.to_nanos_since_midnight == (11 * nanos_per_hour + 11 * nanos_per_minute)
 # 81
-expect Time.fromIsoStr "0000Z" == Time.fromHms 0 0 0 |> Ok
-expect Time.fromIsoStr "0000Z" |> unwrap "Time.fromIsoStr '0000Z'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "0000Z" == Time.from_hms 0 0 0 |> Ok
+expect Time.from_iso_str "0000Z" |> unwrap "Time.fromIsoStr '0000Z'" |> Time.to_nanos_since_midnight == 0
 # 82
-expect Time.fromIsoStr "T0000" == Time.fromHms 0 0 0 |> Ok
-expect Time.fromIsoStr "T0000" |> unwrap "Time.fromIsoStr 'T0000'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "T0000" == Time.from_hms 0 0 0 |> Ok
+expect Time.from_iso_str "T0000" |> unwrap "Time.fromIsoStr 'T0000'" |> Time.to_nanos_since_midnight == 0
 # 83
-expect Time.fromIsoStr "T0000Z" == Time.fromHms 0 0 0 |> Ok
-expect Time.fromIsoStr "T0000Z" |> unwrap "Time.fromIsoStr 'T0000Z'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "T0000Z" == Time.from_hms 0 0 0 |> Ok
+expect Time.from_iso_str "T0000Z" |> unwrap "Time.fromIsoStr 'T0000Z'" |> Time.to_nanos_since_midnight == 0
 # 84
-expect Time.fromIsoStr "T2359" == Time.fromHms 23 59 0 |> Ok
-expect Time.fromIsoStr "T2359" |> unwrap "Time.fromIsoStr 'T2359'" |> Time.toNanosSinceMidnight == (23 * nanosPerHour + 59 * nanosPerMinute)
+expect Time.from_iso_str "T2359" == Time.from_hms 23 59 0 |> Ok
+expect Time.from_iso_str "T2359" |> unwrap "Time.fromIsoStr 'T2359'" |> Time.to_nanos_since_midnight == (23 * nanos_per_hour + 59 * nanos_per_minute)
 # 85
-expect Time.fromIsoStr "T2400" == Time.fromHms 24 0 0 |> Ok
-expect Time.fromIsoStr "T2400" |> unwrap "Time.fromIsoStr 'T2400'" |> Time.toNanosSinceMidnight == (24 * nanosPerHour)
+expect Time.from_iso_str "T2400" == Time.from_hms 24 0 0 |> Ok
+expect Time.from_iso_str "T2400" |> unwrap "Time.fromIsoStr 'T2400'" |> Time.to_nanos_since_midnight == (24 * nanos_per_hour)
 # 86
-expect Time.fromIsoStr "T2401" == Err InvalidTimeFormat
+expect Time.from_iso_str "T2401" == Err InvalidTimeFormat
 # 87
-expect Time.fromIsoStr "T000Z" == Err InvalidTimeFormat
+expect Time.from_iso_str "T000Z" == Err InvalidTimeFormat
 
 # parseLocalTimeMinuteExtended
 # 88
-expect Time.fromIsoStr "11:11" == Time.fromHms 11 11 0 |> Ok
-expect Time.fromIsoStr "11:11" |> unwrap "Time.fromIsoStr '11:11'" |> Time.toNanosSinceMidnight == (11 * nanosPerHour + 11 * nanosPerMinute)
+expect Time.from_iso_str "11:11" == Time.from_hms 11 11 0 |> Ok
+expect Time.from_iso_str "11:11" |> unwrap "Time.fromIsoStr '11:11'" |> Time.to_nanos_since_midnight == (11 * nanos_per_hour + 11 * nanos_per_minute)
 # 89
-expect Time.fromIsoStr "00:00Z" == Time.midnight |> Ok
-expect Time.fromIsoStr "00:00Z" |> unwrap "Time.fromIsoStr '00:00Z'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "00:00Z" == Time.midnight |> Ok
+expect Time.from_iso_str "00:00Z" |> unwrap "Time.fromIsoStr '00:00Z'" |> Time.to_nanos_since_midnight == 0
 # 90
-expect Time.fromIsoStr "T00:00" == Time.midnight |> Ok
-expect Time.fromIsoStr "T00:00" |> unwrap "Time.fromIsoStr 'T00:00'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "T00:00" == Time.midnight |> Ok
+expect Time.from_iso_str "T00:00" |> unwrap "Time.fromIsoStr 'T00:00'" |> Time.to_nanos_since_midnight == 0
 # 91
-expect Time.fromIsoStr "T00:00Z" == Time.midnight |> Ok
-expect Time.fromIsoStr "T00:00Z" |> unwrap "Time.fromIsoStr 'T00:00Z'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "T00:00Z" == Time.midnight |> Ok
+expect Time.from_iso_str "T00:00Z" |> unwrap "Time.fromIsoStr 'T00:00Z'" |> Time.to_nanos_since_midnight == 0
 # 92
-expect Time.fromIsoStr "T23:59" == Time.fromHms 23 59 0 |> Ok
-expect Time.fromIsoStr "T23:59" |> unwrap "Time.fromIsoStr 'T23:59'" |> Time.toNanosSinceMidnight == (23 * nanosPerHour + 59 * nanosPerMinute)
+expect Time.from_iso_str "T23:59" == Time.from_hms 23 59 0 |> Ok
+expect Time.from_iso_str "T23:59" |> unwrap "Time.fromIsoStr 'T23:59'" |> Time.to_nanos_since_midnight == (23 * nanos_per_hour + 59 * nanos_per_minute)
 # 93
-expect Time.fromIsoStr "T24:00" == Time.fromHms 24 0 0 |> Ok
-expect Time.fromIsoStr "T24:00" |> unwrap "Time.fromIsoStr 'T24:00'" |> Time.toNanosSinceMidnight == (24 * nanosPerHour)
+expect Time.from_iso_str "T24:00" == Time.from_hms 24 0 0 |> Ok
+expect Time.from_iso_str "T24:00" |> unwrap "Time.fromIsoStr 'T24:00'" |> Time.to_nanos_since_midnight == (24 * nanos_per_hour)
 # 94
-expect Time.fromIsoStr "T24:01" == Err InvalidTimeFormat
+expect Time.from_iso_str "T24:01" == Err InvalidTimeFormat
 # 95
-expect Time.fromIsoStr "T00:0Z" == Err InvalidTimeFormat
+expect Time.from_iso_str "T00:0Z" == Err InvalidTimeFormat
 
 # parseLocalTimeBasic
 # 96
-expect Time.fromIsoStr "111111" == Time.fromHms 11 11 11 |> Ok
-expect Time.fromIsoStr "111111" |> unwrap "Time.fromIsoStr '111111'" |> Time.toNanosSinceMidnight == (11 * nanosPerHour + 11 * nanosPerMinute + 11 * nanosPerSecond)
+expect Time.from_iso_str "111111" == Time.from_hms 11 11 11 |> Ok
+expect Time.from_iso_str "111111" |> unwrap "Time.fromIsoStr '111111'" |> Time.to_nanos_since_midnight == (11 * nanos_per_hour + 11 * nanos_per_minute + 11 * nanos_per_second)
 # 97
-expect Time.fromIsoStr "000000Z" == Time.midnight |> Ok
-expect Time.fromIsoStr "000000Z" |> unwrap "Time.fromIsoStr '000000Z'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "000000Z" == Time.midnight |> Ok
+expect Time.from_iso_str "000000Z" |> unwrap "Time.fromIsoStr '000000Z'" |> Time.to_nanos_since_midnight == 0
 # 98
-expect Time.fromIsoStr "T000000" == Time.midnight |> Ok
-expect Time.fromIsoStr "T000000" |> unwrap "Time.fromIsoStr 'T000000'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "T000000" == Time.midnight |> Ok
+expect Time.from_iso_str "T000000" |> unwrap "Time.fromIsoStr 'T000000'" |> Time.to_nanos_since_midnight == 0
 # 99
-expect Time.fromIsoStr "T000000Z" == Time.midnight |> Ok
-expect Time.fromIsoStr "T000000Z" |> unwrap "Time.fromIsoStr 'T000000Z'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "T000000Z" == Time.midnight |> Ok
+expect Time.from_iso_str "T000000Z" |> unwrap "Time.fromIsoStr 'T000000Z'" |> Time.to_nanos_since_midnight == 0
 # 100
-expect Time.fromIsoStr "T235959" == Time.fromHms 23 59 59 |> Ok
-expect Time.fromIsoStr "T235959" |> unwrap "Time.fromIsoStr 'T235959'" |> Time.toNanosSinceMidnight == (23 * nanosPerHour + 59 * nanosPerMinute + 59 * nanosPerSecond)
+expect Time.from_iso_str "T235959" == Time.from_hms 23 59 59 |> Ok
+expect Time.from_iso_str "T235959" |> unwrap "Time.fromIsoStr 'T235959'" |> Time.to_nanos_since_midnight == (23 * nanos_per_hour + 59 * nanos_per_minute + 59 * nanos_per_second)
 # 101
-expect Time.fromIsoStr "T240000" == Time.fromHms 24 0 0 |> Ok
-expect Time.fromIsoStr "T240000" |> unwrap "Time.fromIsoStr 'T240000'" |> Time.toNanosSinceMidnight == (24 * nanosPerHour)
+expect Time.from_iso_str "T240000" == Time.from_hms 24 0 0 |> Ok
+expect Time.from_iso_str "T240000" |> unwrap "Time.fromIsoStr 'T240000'" |> Time.to_nanos_since_midnight == (24 * nanos_per_hour)
 # 102
-expect Time.fromIsoStr "T240001" == Err InvalidTimeFormat
+expect Time.from_iso_str "T240001" == Err InvalidTimeFormat
 # 103
-expect Time.fromIsoStr "T00000Z" == Err InvalidTimeFormat
+expect Time.from_iso_str "T00000Z" == Err InvalidTimeFormat
 
 # parseLocalTimeExtended
 # 104
-expect Time.fromIsoStr "11:11:11" == Time.fromHms 11 11 11 |> Ok
-expect Time.fromIsoStr "11:11:11" |> unwrap "Time.fromIsoStr '11:11:11'" |> Time.toNanosSinceMidnight == (11 * nanosPerHour + 11 * nanosPerMinute + 11 * nanosPerSecond)
+expect Time.from_iso_str "11:11:11" == Time.from_hms 11 11 11 |> Ok
+expect Time.from_iso_str "11:11:11" |> unwrap "Time.fromIsoStr '11:11:11'" |> Time.to_nanos_since_midnight == (11 * nanos_per_hour + 11 * nanos_per_minute + 11 * nanos_per_second)
 # 105
-expect Time.fromIsoStr "00:00:00Z" == Time.midnight |> Ok
-expect Time.fromIsoStr "00:00:00Z" |> unwrap "Time.fromIsoStr '00:00:00Z'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "00:00:00Z" == Time.midnight |> Ok
+expect Time.from_iso_str "00:00:00Z" |> unwrap "Time.fromIsoStr '00:00:00Z'" |> Time.to_nanos_since_midnight == 0
 # 106
-expect Time.fromIsoStr "T00:00:00" == Time.midnight |> Ok
-expect Time.fromIsoStr "T00:00:00" |> unwrap "Time.fromIsoStr 'T00:00:00'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "T00:00:00" == Time.midnight |> Ok
+expect Time.from_iso_str "T00:00:00" |> unwrap "Time.fromIsoStr 'T00:00:00'" |> Time.to_nanos_since_midnight == 0
 # 107
-expect Time.fromIsoStr "T00:00:00Z" == Time.midnight |> Ok
-expect Time.fromIsoStr "T00:00:00Z" |> unwrap "Time.fromIsoStr 'T00:00:00Z'" |> Time.toNanosSinceMidnight == 0
+expect Time.from_iso_str "T00:00:00Z" == Time.midnight |> Ok
+expect Time.from_iso_str "T00:00:00Z" |> unwrap "Time.fromIsoStr 'T00:00:00Z'" |> Time.to_nanos_since_midnight == 0
 # 108
-expect Time.fromIsoStr "T23:59:59" == Time.fromHms 23 59 59 |> Ok
-expect Time.fromIsoStr "T23:59:59" |> unwrap "Time.fromIsoStr 'T23:59:59'" |> Time.toNanosSinceMidnight == (23 * nanosPerHour + 59 * nanosPerMinute + 59 * nanosPerSecond)
+expect Time.from_iso_str "T23:59:59" == Time.from_hms 23 59 59 |> Ok
+expect Time.from_iso_str "T23:59:59" |> unwrap "Time.fromIsoStr 'T23:59:59'" |> Time.to_nanos_since_midnight == (23 * nanos_per_hour + 59 * nanos_per_minute + 59 * nanos_per_second)
 # 109
-expect Time.fromIsoStr "T24:00:00" == Time.fromHms 24 0 0 |> Ok
-expect Time.fromIsoStr "T24:00:00" |> unwrap "Time.fromIsoStr 'T24:00:00'" |> Time.toNanosSinceMidnight == (24 * nanosPerHour)
+expect Time.from_iso_str "T24:00:00" == Time.from_hms 24 0 0 |> Ok
+expect Time.from_iso_str "T24:00:00" |> unwrap "Time.fromIsoStr 'T24:00:00'" |> Time.to_nanos_since_midnight == (24 * nanos_per_hour)
 # 110
-expect Time.fromIsoStr "T24:00:01" == Err InvalidTimeFormat
+expect Time.from_iso_str "T24:00:01" == Err InvalidTimeFormat
 # 111
-expect Time.fromIsoStr "T00:00:0Z" == Err InvalidTimeFormat
+expect Time.from_iso_str "T00:00:0Z" == Err InvalidTimeFormat
 
 # parseFractionalTime
 # 112
-expect Time.fromIsoStr "12.500" == Time.fromHms 12 30 0 |> Ok
-expect Time.fromIsoStr "12.500" |> unwrap "Time.fromIsoStr '12.500'" |> Time.toNanosSinceMidnight == (12 * nanosPerHour + 30 * nanosPerMinute)
+expect Time.from_iso_str "12.500" == Time.from_hms 12 30 0 |> Ok
+expect Time.from_iso_str "12.500" |> unwrap "Time.fromIsoStr '12.500'" |> Time.to_nanos_since_midnight == (12 * nanos_per_hour + 30 * nanos_per_minute)
 # 113
-expect Time.fromIsoStr "12,500" == Time.fromHms 12 30 0 |> Ok
-expect Time.fromIsoStr "12,500" |> unwrap "Time.fromIsoStr '12,500'" |> Time.toNanosSinceMidnight == (12 * nanosPerHour + 30 * nanosPerMinute)
+expect Time.from_iso_str "12,500" == Time.from_hms 12 30 0 |> Ok
+expect Time.from_iso_str "12,500" |> unwrap "Time.fromIsoStr '12,500'" |> Time.to_nanos_since_midnight == (12 * nanos_per_hour + 30 * nanos_per_minute)
 # 114
-expect Time.fromIsoStr "1200.500" == Time.fromHms 12 0 30 |> Ok
-expect Time.fromIsoStr "1200.500" |> unwrap "Time.fromIsoStr '1200.500'" |> Time.toNanosSinceMidnight == (12 * nanosPerHour + 30 * nanosPerSecond)
+expect Time.from_iso_str "1200.500" == Time.from_hms 12 0 30 |> Ok
+expect Time.from_iso_str "1200.500" |> unwrap "Time.fromIsoStr '1200.500'" |> Time.to_nanos_since_midnight == (12 * nanos_per_hour + 30 * nanos_per_second)
 # 115
-expect Time.fromIsoStr "12:00,500" == Time.fromHms 12 0 30 |> Ok
-expect Time.fromIsoStr "12:00,500" |> unwrap "Time.fromIsoStr '12:00,500'" |> Time.toNanosSinceMidnight == (12 * nanosPerHour + 30 * nanosPerSecond)
+expect Time.from_iso_str "12:00,500" == Time.from_hms 12 0 30 |> Ok
+expect Time.from_iso_str "12:00,500" |> unwrap "Time.fromIsoStr '12:00,500'" |> Time.to_nanos_since_midnight == (12 * nanos_per_hour + 30 * nanos_per_second)
 # 116
-expect Time.fromIsoStr "12:00:00,123" == Time.fromHmsn 12 0 0 123_000_000 |> Ok
-expect Time.fromIsoStr "12:00:00,123" |> unwrap "Time.fromIsoStr '12:00:00,123'" |> Time.toNanosSinceMidnight == (12 * nanosPerHour + 123_000_000)
+expect Time.from_iso_str "12:00:00,123" == Time.from_hmsn 12 0 0 123_000_000 |> Ok
+expect Time.from_iso_str "12:00:00,123" |> unwrap "Time.fromIsoStr '12:00:00,123'" |> Time.to_nanos_since_midnight == (12 * nanos_per_hour + 123_000_000)
 
 # parseTime w/ offset
 # 117
-expect Time.fromIsoStr "12:00:00+01" == Time.fromHms 11 0 0 |> Ok
-expect Time.fromIsoStr "12:00:00+01" |> unwrap "Time.fromIsoStr '12:00:00+01'" |> Time.toNanosSinceMidnight == (11 * nanosPerHour)
+expect Time.from_iso_str "12:00:00+01" == Time.from_hms 11 0 0 |> Ok
+expect Time.from_iso_str "12:00:00+01" |> unwrap "Time.fromIsoStr '12:00:00+01'" |> Time.to_nanos_since_midnight == (11 * nanos_per_hour)
 # 118
-expect Time.fromIsoStr "12:00:00-01" == Time.fromHms 13 0 0 |> Ok
-expect Time.fromIsoStr "12:00:00-01" |> unwrap "Time.fromIsoStr '12:00:00-01'" |> Time.toNanosSinceMidnight == (13 * nanosPerHour)
+expect Time.from_iso_str "12:00:00-01" == Time.from_hms 13 0 0 |> Ok
+expect Time.from_iso_str "12:00:00-01" |> unwrap "Time.fromIsoStr '12:00:00-01'" |> Time.to_nanos_since_midnight == (13 * nanos_per_hour)
 # 119
-expect Time.fromIsoStr "12:00:00+0100" == Time.fromHms 11 0 0 |> Ok
-expect Time.fromIsoStr "12:00:00+0100" |> unwrap "Time.fromIsoStr '12:00:00+0100'" |> Time.toNanosSinceMidnight == (11 * nanosPerHour)
+expect Time.from_iso_str "12:00:00+0100" == Time.from_hms 11 0 0 |> Ok
+expect Time.from_iso_str "12:00:00+0100" |> unwrap "Time.fromIsoStr '12:00:00+0100'" |> Time.to_nanos_since_midnight == (11 * nanos_per_hour)
 # 120
-expect Time.fromIsoStr "12:00:00-0100" == Time.fromHms 13 0 0 |> Ok
-expect Time.fromIsoStr "12:00:00-0100" |> unwrap "Time.fromIsoStr '12:00:00-0100'" |> Time.toNanosSinceMidnight == (13 * nanosPerHour)
+expect Time.from_iso_str "12:00:00-0100" == Time.from_hms 13 0 0 |> Ok
+expect Time.from_iso_str "12:00:00-0100" |> unwrap "Time.fromIsoStr '12:00:00-0100'" |> Time.to_nanos_since_midnight == (13 * nanos_per_hour)
 # 121
-expect Time.fromIsoStr "12:00:00+01:00" == Time.fromHms 11 0 0 |> Ok
-expect Time.fromIsoStr "12:00:00+01:00" |> unwrap "Time.fromIsoStr '12:00:00+01:00'" |> Time.toNanosSinceMidnight == (11 * nanosPerHour)
+expect Time.from_iso_str "12:00:00+01:00" == Time.from_hms 11 0 0 |> Ok
+expect Time.from_iso_str "12:00:00+01:00" |> unwrap "Time.fromIsoStr '12:00:00+01:00'" |> Time.to_nanos_since_midnight == (11 * nanos_per_hour)
 # 122
-expect Time.fromIsoStr "12:00:00-01:00" == Time.fromHms 13 0 0 |> Ok
-expect Time.fromIsoStr "12:00:00-01:00" |> unwrap "Time.fromIsoStr '12:00:00-01:00'" |> Time.toNanosSinceMidnight == (13 * nanosPerHour)
+expect Time.from_iso_str "12:00:00-01:00" == Time.from_hms 13 0 0 |> Ok
+expect Time.from_iso_str "12:00:00-01:00" |> unwrap "Time.fromIsoStr '12:00:00-01:00'" |> Time.to_nanos_since_midnight == (13 * nanos_per_hour)
 # 123
-expect Time.fromIsoStr "12:00:00+01:30" == Time.fromHms 10 30 0 |> Ok
-expect Time.fromIsoStr "12:00:00+01:30" |> unwrap "Time.fromIsoStr '12:00:00+01:30'" |> Time.toNanosSinceMidnight == (10 * nanosPerHour + 30 * nanosPerMinute)
+expect Time.from_iso_str "12:00:00+01:30" == Time.from_hms 10 30 0 |> Ok
+expect Time.from_iso_str "12:00:00+01:30" |> unwrap "Time.fromIsoStr '12:00:00+01:30'" |> Time.to_nanos_since_midnight == (10 * nanos_per_hour + 30 * nanos_per_minute)
 # 124
-expect Time.fromIsoStr "12:00:00-01:30" == Time.fromHms 13 30 0 |> Ok
-expect Time.fromIsoStr "12:00:00-01:30" |> unwrap "Time.fromIsoStr '12:00:00-01:30'" |> Time.toNanosSinceMidnight == (13 * nanosPerHour + 30 * nanosPerMinute)
+expect Time.from_iso_str "12:00:00-01:30" == Time.from_hms 13 30 0 |> Ok
+expect Time.from_iso_str "12:00:00-01:30" |> unwrap "Time.fromIsoStr '12:00:00-01:30'" |> Time.to_nanos_since_midnight == (13 * nanos_per_hour + 30 * nanos_per_minute)
 # 125
-expect Time.fromIsoStr "12.50+0030" == Time.fromHms 12 0 0 |> Ok
-expect Time.fromIsoStr "12.50+0030" |> unwrap "Time.fromIsoStr '12.50+0030'" |> Time.toNanosSinceMidnight == (12 * nanosPerHour)
+expect Time.from_iso_str "12.50+0030" == Time.from_hms 12 0 0 |> Ok
+expect Time.from_iso_str "12.50+0030" |> unwrap "Time.fromIsoStr '12.50+0030'" |> Time.to_nanos_since_midnight == (12 * nanos_per_hour)
 # 126
-expect Time.fromIsoStr "0000+1400" == Time.fromHms -14 0 0 |> Ok
-expect Time.fromIsoStr "0000+1400" |> unwrap "Time.fromIsoStr '0000+1400'" |> Time.toNanosSinceMidnight == (-14 * nanosPerHour)
+expect Time.from_iso_str "0000+1400" == Time.from_hms -14 0 0 |> Ok
+expect Time.from_iso_str "0000+1400" |> unwrap "Time.fromIsoStr '0000+1400'" |> Time.to_nanos_since_midnight == (-14 * nanos_per_hour)
 # 127
-expect Time.fromIsoStr "T24-1200" == Time.fromHms 36 0 0 |> Ok
-expect Time.fromIsoStr "T24-1200" |> unwrap "Time.fromIsoStr 'T24-1200'" |> Time.toNanosSinceMidnight == (36 * nanosPerHour)
+expect Time.from_iso_str "T24-1200" == Time.from_hms 36 0 0 |> Ok
+expect Time.from_iso_str "T24-1200" |> unwrap "Time.fromIsoStr 'T24-1200'" |> Time.to_nanos_since_midnight == (36 * nanos_per_hour)
 # 128
-expect Time.fromIsoStr "1200+1401" == Err InvalidTimeFormat
+expect Time.from_iso_str "1200+1401" == Err InvalidTimeFormat
 # 129
-expect Time.fromIsoStr "1200-1201" == Err InvalidTimeFormat
+expect Time.from_iso_str "1200-1201" == Err InvalidTimeFormat
 # 130
-expect Time.fromIsoStr "T24+1200Z" == Err InvalidTimeFormat
+expect Time.from_iso_str "T24+1200Z" == Err InvalidTimeFormat
 
 # <==== DateTime.roc ====>
 # parseDateTime
 # 131
-expect DateTime.fromIsoStr "20240223T120000Z" == DateTime.fromYmdhms 2024 2 23 12 0 0 |> Ok
-expect DateTime.fromIsoStr "20240223T120000Z" |> unwrap "DateTime.fromIsoStr '20240223T120000Z'" |> DateTime.toNanosSinceEpoch == 19_776 * secondsPerDay * nanosPerSecond + 12 * nanosPerHour
+expect DateTime.from_iso_str "20240223T120000Z" == DateTime.from_ymdhms 2024 2 23 12 0 0 |> Ok
+expect DateTime.from_iso_str "20240223T120000Z" |> unwrap "DateTime.fromIsoStr '20240223T120000Z'" |> DateTime.to_nanos_since_epoch == 19_776 * seconds_per_day * nanos_per_second + 12 * nanos_per_hour
 # 132
-expect DateTime.fromIsoStr "2024-02-23T12:00:00+00:00" == DateTime.fromYmdhms 2024 2 23 12 0 0 |> Ok
-expect DateTime.fromIsoStr "2024-02-23T12:00:00+00:00" |> unwrap "DateTime.fromIsoStr '2024-02-23T12:00:00+00:00'" |> DateTime.toNanosSinceEpoch == 19_776 * secondsPerDay * nanosPerSecond + 12 * nanosPerHour
+expect DateTime.from_iso_str "2024-02-23T12:00:00+00:00" == DateTime.from_ymdhms 2024 2 23 12 0 0 |> Ok
+expect DateTime.from_iso_str "2024-02-23T12:00:00+00:00" |> unwrap "DateTime.fromIsoStr '2024-02-23T12:00:00+00:00'" |> DateTime.to_nanos_since_epoch == 19_776 * seconds_per_day * nanos_per_second + 12 * nanos_per_hour
 # 133
-expect DateTime.fromIsoStr "2024-02-23T00:00:00+14" == DateTime.fromYmdhms 2024 2 22 10 0 0 |> Ok
-expect DateTime.fromIsoStr "2024-02-23T00:00:00+14" |> unwrap "DateTime.fromIsoStr '2024-02-23T00:00:00+14'" |> DateTime.toNanosSinceEpoch == 19_776 * nanosPerDay - 14 * nanosPerHour
+expect DateTime.from_iso_str "2024-02-23T00:00:00+14" == DateTime.from_ymdhms 2024 2 22 10 0 0 |> Ok
+expect DateTime.from_iso_str "2024-02-23T00:00:00+14" |> unwrap "DateTime.fromIsoStr '2024-02-23T00:00:00+14'" |> DateTime.to_nanos_since_epoch == 19_776 * nanos_per_day - 14 * nanos_per_hour
 # 134
-expect DateTime.fromIsoStr "2024-02-23T23:59:59-12" == DateTime.fromYmdhms 2024 2 24 11 59 59 |> Ok
-expect DateTime.fromIsoStr "2024-02-23T23:59:59-12" |> unwrap "DateTime.fromIsoStr '2024-02-23T23:59:59-12'" |> DateTime.toNanosSinceEpoch == 19_776 * Const.nanosPerDay + (Const.nanosPerDay - 1 * nanosPerSecond) + 12 * nanosPerHour
+expect DateTime.from_iso_str "2024-02-23T23:59:59-12" == DateTime.from_ymdhms 2024 2 24 11 59 59 |> Ok
+expect DateTime.from_iso_str "2024-02-23T23:59:59-12" |> unwrap "DateTime.fromIsoStr '2024-02-23T23:59:59-12'" |> DateTime.to_nanos_since_epoch == 19_776 * Const.nanos_per_day + (Const.nanos_per_day - 1 * nanos_per_second) + 12 * nanos_per_hour
 # 135
-expect DateTime.fromIsoStr "2024-02-23T12:00:00+01:30" == DateTime.fromYmdhms 2024 2 23 10 30 0 |> Ok
-expect DateTime.fromIsoStr "2024-02-23T12:00:00+01:30" |> unwrap "DateTime.fromIsoStr '2024-02-23T12:00:00+01:30'" |> DateTime.toNanosSinceEpoch == 19_776 * Const.nanosPerDay + 10 * nanosPerHour + 30 * nanosPerMinute
+expect DateTime.from_iso_str "2024-02-23T12:00:00+01:30" == DateTime.from_ymdhms 2024 2 23 10 30 0 |> Ok
+expect DateTime.from_iso_str "2024-02-23T12:00:00+01:30" |> unwrap "DateTime.fromIsoStr '2024-02-23T12:00:00+01:30'" |> DateTime.to_nanos_since_epoch == 19_776 * Const.nanos_per_day + 10 * nanos_per_hour + 30 * nanos_per_minute
 
 # <==== Utils.roc ====>
 # <---- splitListAtIndices ---->
-expect splitListAtIndices [1, 2] [0, 1, 2] == [[1], [2]]
-expect splitListAtIndices [1, 2] [0] == [[1, 2]]
-expect splitListAtIndices [1, 2] [1] == [[1], [2]]
+expect split_list_at_indices [1, 2] [0, 1, 2] == [[1], [2]]
+expect split_list_at_indices [1, 2] [0] == [[1, 2]]
+expect split_list_at_indices [1, 2] [1] == [[1], [2]]
 
 # <---- splitUtf8AndKeepDelimiters ---->
-expect splitUtf8AndKeepDelimiters [] [] == []
-expect splitUtf8AndKeepDelimiters [] ['-', '+'] == []
-expect splitUtf8AndKeepDelimiters ['1', '2', '3'] [] == [['1', '2', '3']]
-expect splitUtf8AndKeepDelimiters ['1', '2', '3'] ['-', '+'] == [['1', '2', '3']]
-expect splitUtf8AndKeepDelimiters ['0', '1', '+', '2', '3'] ['-', '+'] == [['0', '1'], ['+'], ['2', '3']]
-expect splitUtf8AndKeepDelimiters ['+', '-', '0', '1', '2'] ['-', '+'] == [['+'], ['-'], ['0', '1', '2']]
-expect splitUtf8AndKeepDelimiters ['+', '-'] ['-', '+'] == [['+'], ['-']]
+expect split_utf8_and_keep_delimiters [] [] == []
+expect split_utf8_and_keep_delimiters [] ['-', '+'] == []
+expect split_utf8_and_keep_delimiters ['1', '2', '3'] [] == [['1', '2', '3']]
+expect split_utf8_and_keep_delimiters ['1', '2', '3'] ['-', '+'] == [['1', '2', '3']]
+expect split_utf8_and_keep_delimiters ['0', '1', '+', '2', '3'] ['-', '+'] == [['0', '1'], ['+'], ['2', '3']]
+expect split_utf8_and_keep_delimiters ['+', '-', '0', '1', '2'] ['-', '+'] == [['+'], ['-'], ['0', '1', '2']]
+expect split_utf8_and_keep_delimiters ['+', '-'] ['-', '+'] == [['+'], ['-']]
 
 # <---- validateUtf8SingleBytes ---->
-expect validateUtf8SingleBytes [0b01111111]
-expect !(validateUtf8SingleBytes [0b10000000, 0b00000001])
-expect !("🔥" |> Str.toUtf8 |> validateUtf8SingleBytes)
+expect validate_utf8_single_bytes [0b01111111]
+expect !(validate_utf8_single_bytes [0b10000000, 0b00000001])
+expect !("🔥" |> Str.toUtf8 |> validate_utf8_single_bytes)
 
 # <---- utf8ToInt ---->
-expect ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] |> utf8ToInt == Ok 123456789
-expect utf8ToInt ['@'] == Err InvalidBytes
-expect utf8ToInt ['/'] == Err InvalidBytes
+expect ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] |> utf8_to_int == Ok 123456789
+expect utf8_to_int ['@'] == Err InvalidBytes
+expect utf8_to_int ['/'] == Err InvalidBytes
 
 # <---- utf8ToIntSigned ---->
-expect ['-', '1'] |> utf8ToIntSigned == Ok -1
-expect ['+', '1'] |> utf8ToIntSigned == Ok 1
-expect ['1', '9'] |> utf8ToIntSigned == Ok 19
+expect ['-', '1'] |> utf8_to_int_signed == Ok -1
+expect ['+', '1'] |> utf8_to_int_signed == Ok 1
+expect ['1', '9'] |> utf8_to_int_signed == Ok 19
 
 # <---- utf8ToFrac ---->
 expect
-    when utf8ToFrac ['1', '2', '.', '3', '4', '5'] is
+    when utf8_to_frac ['1', '2', '.', '3', '4', '5'] is
         Ok n -> n > 12.34499 && n < 12.34501
         _ -> Bool.false
 expect
-    when utf8ToFrac ['1', '2', ',', '3', '4', '5'] is
+    when utf8_to_frac ['1', '2', ',', '3', '4', '5'] is
         Ok n -> n > 12.34499 && n < 12.34501
         _ -> Bool.false
 expect
-    when utf8ToFrac ['.', '1', '2', '3'] is
+    when utf8_to_frac ['.', '1', '2', '3'] is
         Ok n -> n > 0.12299 && n < 0.12301
         _ -> Bool.false
 expect
-    when utf8ToFrac [',', '1', '2', '3'] is
+    when utf8_to_frac [',', '1', '2', '3'] is
         Ok n -> n > 0.12299 && n < 0.12301
         _ -> Bool.false
 expect
-    when utf8ToFrac ['1', '2', '3'] is
+    when utf8_to_frac ['1', '2', '3'] is
         Ok n -> n > 122.99 && n < 123.01
         _ -> Bool.false
 expect
-    when utf8ToFrac ['1', '2', '3', '.'] is
+    when utf8_to_frac ['1', '2', '3', '.'] is
         Ok n -> n > 122.99 && n < 123.01
         _ -> Bool.false
 expect
-    num = utf8ToFrac ['1', '2', 'Z']
+    num = utf8_to_frac ['1', '2', 'Z']
     when num is
         Err InvalidBytes -> Bool.true
         _ -> Bool.false
 expect
-    num = utf8ToFrac ['T', '2', '3']
+    num = utf8_to_frac ['T', '2', '3']
     when num is
         Err InvalidBytes -> Bool.true
         _ -> Bool.false

--- a/package/Time.roc
+++ b/package/Time.roc
@@ -2,49 +2,49 @@
 ##
 ## These functions include functions for creating `Time` objects from various numeric values, converting `Time`s to and from ISO 8601 strings, and performing arithmetic operations on `Time`s.
 module [
-    addDurationAndTime,
-    addHours,
-    addMinutes,
-    addNanoseconds,
-    addSeconds,
-    addTimeAndDuration,
-    fromHms,
-    fromHmsn,
-    fromIsoStr,
-    fromIsoU8,
-    fromNanosSinceMidnight,
+    add_duration_and_time,
+    add_hours,
+    add_minutes,
+    add_nanoseconds,
+    add_seconds,
+    add_time_and_duration,
+    from_hms,
+    from_hmsn,
+    from_iso_str,
+    from_iso_u8,
+    from_nanos_since_midnight,
     midnight,
     normalize,
     Time,
-    toIsoStr,
-    toIsoU8,
-    toNanosSinceMidnight,
+    to_iso_str,
+    to_iso_u8,
+    to_nanos_since_midnight,
 ]
 
 import Const
 import Const exposing [
-    nanosPerHour,
-    nanosPerMinute,
-    nanosPerSecond,
+    nanos_per_hour,
+    nanos_per_minute,
+    nanos_per_second,
 ]
 import Duration
 import Duration exposing [Duration]
 import Utils exposing [
-    expandIntWithZeros,
-    splitListAtIndices,
-    splitUtf8AndKeepDelimiters,
-    utf8ToFrac,
-    utf8ToIntSigned,
-    validateUtf8SingleBytes,
+    expand_int_with_zeros,
+    split_list_at_indices,
+    split_utf8_and_keep_delimiters,
+    utf8_to_frac,
+    utf8_to_int_signed,
+    validate_utf8_single_bytes,
 ]
 import Unsafe exposing [unwrap] # for unit testing only
 
 ## ```
-## Time : { 
-##     hour : I8, 
-##     minute : U8, 
-##     second : U8, 
-##     nanosecond : U32 
+## Time : {
+##     hour : I8,
+##     minute : U8,
+##     second : U8,
+##     nanosecond : U32
 ## }
 ## ```
 Time : { hour : I8, minute : U8, second : U8, nanosecond : U32 }
@@ -55,286 +55,286 @@ midnight = { hour: 0, minute: 0, second: 0, nanosecond: 0 }
 
 normalize : Time -> Time
 normalize = \time ->
-    hNormalized = time.hour |> Num.rem Const.hoursPerDay |> Num.add Const.hoursPerDay |> Num.rem Const.hoursPerDay
-    fromHmsn hNormalized time.minute time.second time.nanosecond
+    h_normalized = time.hour |> Num.rem Const.hours_per_day |> Num.add Const.hours_per_day |> Num.rem Const.hours_per_day
+    from_hmsn h_normalized time.minute time.second time.nanosecond
 
-expect Time.normalize (fromHms -1 0 0) == fromHms 23 0 0
-expect Time.normalize (fromHms 24 0 0) == fromHms 0 0 0
-expect Time.normalize (fromHms 25 0 0) == fromHms 1 0 0
+expect Time.normalize (from_hms -1 0 0) == from_hms 23 0 0
+expect Time.normalize (from_hms 24 0 0) == from_hms 0 0 0
+expect Time.normalize (from_hms 25 0 0) == from_hms 1 0 0
 
 ## Create a `Time` object from the hour, minute, and second.
-fromHms : Int *, Int *, Int * -> Time
-fromHms = \hour, minute, second -> { hour: Num.toI8 hour, minute: Num.toU8 minute, second: Num.toU8 second, nanosecond: 0u32 }
+from_hms : Int *, Int *, Int * -> Time
+from_hms = \hour, minute, second -> { hour: Num.toI8 hour, minute: Num.toU8 minute, second: Num.toU8 second, nanosecond: 0u32 }
 
 ## Create a `Time` object from the hour, minute, second, and nanosecond.
-fromHmsn : Int *, Int *, Int *, Int * -> Time
-fromHmsn = \hour, minute, second, nanosecond ->
+from_hmsn : Int *, Int *, Int *, Int * -> Time
+from_hmsn = \hour, minute, second, nanosecond ->
     { hour: Num.toI8 hour, minute: Num.toU8 minute, second: Num.toU8 second, nanosecond: Num.toU32 nanosecond }
 
 ## Convert nanoseconds since midnight to a `Time` object.
-toNanosSinceMidnight : Time -> I64
-toNanosSinceMidnight = \time ->
-    hNanos = time.hour |> Num.toI64 |> Num.mul Const.nanosPerHour |> Num.toI64
-    mNanos = time.minute |> Num.toI64 |> Num.mul Const.nanosPerMinute |> Num.toI64
-    sNanos = time.second |> Num.toI64 |> Num.mul Const.nanosPerSecond |> Num.toI64
+to_nanos_since_midnight : Time -> I64
+to_nanos_since_midnight = \time ->
+    h_nanos = time.hour |> Num.toI64 |> Num.mul Const.nanos_per_hour |> Num.toI64
+    m_nanos = time.minute |> Num.toI64 |> Num.mul Const.nanos_per_minute |> Num.toI64
+    s_nanos = time.second |> Num.toI64 |> Num.mul Const.nanos_per_second |> Num.toI64
     nanos = time.nanosecond |> Num.toI64
-    hNanos + mNanos + sNanos + nanos
+    h_nanos + m_nanos + s_nanos + nanos
 
 ## Convert a `Time` object to the number of nanoseconds since midnight.
-fromNanosSinceMidnight : Int * -> Time
-fromNanosSinceMidnight = \nanos ->
-    nanos1 = nanos |> Num.rem Const.nanosPerDay |> Num.add Const.nanosPerDay |> Num.rem Const.nanosPerDay |> Num.toU64
-    nanos2 = nanos1 % nanosPerHour
-    minute = nanos2 // nanosPerMinute |> Num.toU8
-    nanos3 = nanos2 % nanosPerMinute
-    second = nanos3 // nanosPerSecond |> Num.toU8
-    nanosecond = nanos3 % nanosPerSecond |> Num.toU32
-    hour = (nanos - Num.intCast (Num.toI64 minute * nanosPerMinute + Num.toI64 second * nanosPerSecond + Num.toI64 nanosecond)) // nanosPerHour |> Num.toI8 # % Const.hoursPerDay |> Num.toI8
+from_nanos_since_midnight : Int * -> Time
+from_nanos_since_midnight = \nanos ->
+    nanos1 = nanos |> Num.rem Const.nanos_per_day |> Num.add Const.nanos_per_day |> Num.rem Const.nanos_per_day |> Num.toU64
+    nanos2 = nanos1 % nanos_per_hour
+    minute = nanos2 // nanos_per_minute |> Num.toU8
+    nanos3 = nanos2 % nanos_per_minute
+    second = nanos3 // nanos_per_second |> Num.toU8
+    nanosecond = nanos3 % nanos_per_second |> Num.toU32
+    hour = (nanos - Num.intCast (Num.toI64 minute * nanos_per_minute + Num.toI64 second * nanos_per_second + Num.toI64 nanosecond)) // nanos_per_hour |> Num.toI8 # % Const.hoursPerDay |> Num.toI8
     { hour, minute, second, nanosecond }
 
 ## Add nanoseconds to a `Time` object.
-addNanoseconds : Time, Int * -> Time
-addNanoseconds = \time, nanos ->
-    toNanosSinceMidnight time + Num.toI64 nanos |> fromNanosSinceMidnight
+add_nanoseconds : Time, Int * -> Time
+add_nanoseconds = \time, nanos ->
+    to_nanos_since_midnight time + Num.toI64 nanos |> from_nanos_since_midnight
 
 ## Add seconds to a `Time` object.
-addSeconds : Time, Int * -> Time
-addSeconds = \time, seconds -> addNanoseconds time (seconds * Const.nanosPerSecond)
+add_seconds : Time, Int * -> Time
+add_seconds = \time, seconds -> add_nanoseconds time (seconds * Const.nanos_per_second)
 
 ## Add minutes to a `Time` object.
-addMinutes : Time, Int * -> Time
-addMinutes = \time, minutes -> addNanoseconds time (minutes * Const.nanosPerMinute)
+add_minutes : Time, Int * -> Time
+add_minutes = \time, minutes -> add_nanoseconds time (minutes * Const.nanos_per_minute)
 
 ## Add hours to a `Time` object.
-addHours : Time, Int * -> Time
-addHours = \time, hours -> addNanoseconds time (hours * Const.nanosPerHour)
+add_hours : Time, Int * -> Time
+add_hours = \time, hours -> add_nanoseconds time (hours * Const.nanos_per_hour)
 
 ## Add a `Duration` object to a `Time` object.
-addDurationAndTime : Duration, Time -> Time
-addDurationAndTime = \duration, time ->
-    durationNanos = Duration.toNanoseconds duration
-    timeNanos = toNanosSinceMidnight time |> Num.toI128
-    (durationNanos + timeNanos) |> fromNanosSinceMidnight
+add_duration_and_time : Duration, Time -> Time
+add_duration_and_time = \duration, time ->
+    duration_nanos = Duration.to_nanoseconds duration
+    time_nanos = to_nanos_since_midnight time |> Num.toI128
+    (duration_nanos + time_nanos) |> from_nanos_since_midnight
 
 ## Add a `Time` object to a `Duration` object.
-addTimeAndDuration : Time, Duration -> Time
-addTimeAndDuration = \time, duration -> addDurationAndTime duration time
+add_time_and_duration : Time, Duration -> Time
+add_time_and_duration = \time, duration -> add_duration_and_time duration time
 
-stripTandZ : List U8 -> List U8
-stripTandZ = \bytes ->
+strip_tand_z : List U8 -> List U8
+strip_tand_z = \bytes ->
     when bytes is
-        ['T', .. as tail] -> stripTandZ tail
+        ['T', .. as tail] -> strip_tand_z tail
         [.. as head, 'Z'] -> head
         _ -> bytes
 
 ## Convert a `Time` object to an ISO 8601 string.
-toIsoStr : Time -> Str
-toIsoStr = \time ->
-    expandIntWithZeros time.hour 2
+to_iso_str : Time -> Str
+to_iso_str = \time ->
+    expand_int_with_zeros time.hour 2
     |> Str.concat ":"
-    |> Str.concat (expandIntWithZeros time.minute 2)
+    |> Str.concat (expand_int_with_zeros time.minute 2)
     |> Str.concat ":"
-    |> Str.concat (expandIntWithZeros time.second 2)
-    |> Str.concat (nanosToFracStr time.nanosecond)
+    |> Str.concat (expand_int_with_zeros time.second 2)
+    |> Str.concat (nanos_to_frac_str time.nanosecond)
 
-nanosToFracStr : U32 -> Str
-nanosToFracStr = \nanos ->
-    length = countFracWidth nanos 9
-    untrimmedStr = (if nanos == 0 then "" else Str.concat "," (expandIntWithZeros nanos length))
-    when untrimmedStr |> Str.toUtf8 |> List.takeFirst (length + 1) |> Str.fromUtf8 is
+nanos_to_frac_str : U32 -> Str
+nanos_to_frac_str = \nanos ->
+    length = count_frac_width nanos 9
+    untrimmed_str = (if nanos == 0 then "" else Str.concat "," (expand_int_with_zeros nanos length))
+    when untrimmed_str |> Str.toUtf8 |> List.takeFirst (length + 1) |> Str.fromUtf8 is
         Ok str -> str
-        Err _ -> untrimmedStr
+        Err _ -> untrimmed_str
 
-countFracWidth : U32, Int _ -> Int _
-countFracWidth = \num, width ->
+count_frac_width : U32, Int _ -> Int _
+count_frac_width = \num, width ->
     if num == 0 then
         0
     else if num % 10 == 0 then
-        countFracWidth (num // 10) (width - 1)
+        count_frac_width (num // 10) (width - 1)
     else
         width
 
 ## Convert a `Time` object to an ISO 8601 list of UTF-8 bytes.
-toIsoU8 : Time -> List U8
-toIsoU8 = \time -> toIsoStr time |> Str.toUtf8
+to_iso_u8 : Time -> List U8
+to_iso_u8 = \time -> to_iso_str time |> Str.toUtf8
 
 ## Convert an ISO 8601 string to a `Time` object.
-fromIsoStr : Str -> Result Time [InvalidTimeFormat]
-fromIsoStr = \str -> Str.toUtf8 str |> fromIsoU8
+from_iso_str : Str -> Result Time [InvalidTimeFormat]
+from_iso_str = \str -> Str.toUtf8 str |> from_iso_u8
 
 ## Convert an ISO 8601 list of UTF-8 bytes to a `Time` object.
-fromIsoU8 : List U8 -> Result Time [InvalidTimeFormat]
-fromIsoU8 = \bytes ->
-    if validateUtf8SingleBytes bytes then
-        strippedBytes = stripTandZ bytes
-        when (splitUtf8AndKeepDelimiters strippedBytes ['.', ',', '+', '-'], List.last bytes) is
+from_iso_u8 : List U8 -> Result Time [InvalidTimeFormat]
+from_iso_u8 = \bytes ->
+    if validate_utf8_single_bytes bytes then
+        stripped_bytes = strip_tand_z bytes
+        when (split_utf8_and_keep_delimiters stripped_bytes ['.', ',', '+', '-'], List.last bytes) is
             # time.fractionaltime+timeoffset / time,fractionaltime-timeoffset
-            ([timeBytes, [byte1], fractionalBytes, [byte2], offsetBytes], Ok lastByte) if lastByte != 'Z' ->
-                timeRes = parseFractionalTime timeBytes (List.join [[byte1], fractionalBytes])
-                offsetRes = parseTimeOffset (List.join [[byte2], offsetBytes])
-                combineTimeAndOffsetResults timeRes offsetRes
+            ([time_bytes, [byte1], fractional_bytes, [byte2], offset_bytes], Ok last_byte) if last_byte != 'Z' ->
+                time_res = parse_fractional_time time_bytes (List.join [[byte1], fractional_bytes])
+                offset_res = parse_time_offset (List.join [[byte2], offset_bytes])
+                combine_time_and_offset_results time_res offset_res
 
             # time+timeoffset / time-timeoffset
-            ([timeBytes, [byte1], offsetBytes], Ok lastByte) if (byte1 == '+' || byte1 == '-') && lastByte != 'Z' ->
-                timeRes = parseWholeTime timeBytes
-                offsetRes = parseTimeOffset (List.join [[byte1], offsetBytes])
-                combineTimeAndOffsetResults timeRes offsetRes
+            ([time_bytes, [byte1], offset_bytes], Ok last_byte) if (byte1 == '+' || byte1 == '-') && last_byte != 'Z' ->
+                time_res = parse_whole_time time_bytes
+                offset_res = parse_time_offset (List.join [[byte1], offset_bytes])
+                combine_time_and_offset_results time_res offset_res
 
             # time.fractionaltime / time,fractionaltime
-            ([timeBytes, [byte1], fractionalBytes], _) if byte1 == ',' || byte1 == '.' ->
-                parseFractionalTime timeBytes (List.join [[byte1], fractionalBytes])
+            ([time_bytes, [byte1], fractional_bytes], _) if byte1 == ',' || byte1 == '.' ->
+                parse_fractional_time time_bytes (List.join [[byte1], fractional_bytes])
 
             # time
-            ([timeBytes], _) -> parseWholeTime timeBytes
+            ([time_bytes], _) -> parse_whole_time time_bytes
             _ -> Err InvalidTimeFormat
     else
         Err InvalidTimeFormat
 
-combineTimeAndOffsetResults = \timeRes, offsetRes ->
-    when (timeRes, offsetRes) is
+combine_time_and_offset_results = \time_res, offset_res ->
+    when (time_res, offset_res) is
         (Ok time, Ok offset) ->
-            Time.addTimeAndDuration time offset |> Ok
+            Time.add_time_and_duration time offset |> Ok
 
         (_, _) -> Err InvalidTimeFormat
 
-parseWholeTime : List U8 -> Result Time [InvalidTimeFormat]
-parseWholeTime = \bytes ->
+parse_whole_time : List U8 -> Result Time [InvalidTimeFormat]
+parse_whole_time = \bytes ->
     when bytes is
-        [_, _] -> parseLocalTimeHour bytes # hh
-        [_, _, _, _] -> parseLocalTimeMinuteBasic bytes # hhmm
-        [_, _, ':', _, _] -> parseLocalTimeMinuteExtended bytes # hh:mm
-        [_, _, _, _, _, _] -> parseLocalTimeBasic bytes # hhmmss
-        [_, _, ':', _, _, ':', _, _] -> parseLocalTimeExtended bytes # hh:mm:ss
+        [_, _] -> parse_local_time_hour bytes # hh
+        [_, _, _, _] -> parse_local_time_minute_basic bytes # hhmm
+        [_, _, ':', _, _] -> parse_local_time_minute_extended bytes # hh:mm
+        [_, _, _, _, _, _] -> parse_local_time_basic bytes # hhmmss
+        [_, _, ':', _, _, ':', _, _] -> parse_local_time_extended bytes # hh:mm:ss
         _ -> Err InvalidTimeFormat
 
-parseFractionalTime : List U8, List U8 -> Result Time [InvalidTimeFormat]
-parseFractionalTime = \wholeBytes, fractionalBytes ->
-    combineDurationResAndTime = \durationRes, time ->
-        when durationRes is
-            Ok duration -> Time.addTimeAndDuration time duration |> Ok
+parse_fractional_time : List U8, List U8 -> Result Time [InvalidTimeFormat]
+parse_fractional_time = \whole_bytes, fractional_bytes ->
+    combine_duration_res_and_time = \duration_res, time ->
+        when duration_res is
+            Ok duration -> Time.add_time_and_duration time duration |> Ok
             Err _ -> Err InvalidTimeFormat
-    when (wholeBytes, utf8ToFrac fractionalBytes) is
+    when (whole_bytes, utf8_to_frac fractional_bytes) is
         ([_, _], Ok frac) -> # hh
-            time = parseLocalTimeHour? wholeBytes
-            frac * Const.nanosPerHour |> Num.round |> Duration.fromNanoseconds |> combineDurationResAndTime time
+            time = parse_local_time_hour? whole_bytes
+            frac * Const.nanos_per_hour |> Num.round |> Duration.from_nanoseconds |> combine_duration_res_and_time time
 
         ([_, _, _, _], Ok frac) -> # hhmm
-            time = parseLocalTimeMinuteBasic? wholeBytes
-            frac * Const.nanosPerMinute |> Num.round |> Duration.fromNanoseconds |> combineDurationResAndTime time
+            time = parse_local_time_minute_basic? whole_bytes
+            frac * Const.nanos_per_minute |> Num.round |> Duration.from_nanoseconds |> combine_duration_res_and_time time
 
         ([_, _, ':', _, _], Ok frac) -> # hh:mm
-            time = parseLocalTimeMinuteExtended? wholeBytes
-            frac * Const.nanosPerMinute |> Num.round |> Duration.fromNanoseconds |> combineDurationResAndTime time
+            time = parse_local_time_minute_extended? whole_bytes
+            frac * Const.nanos_per_minute |> Num.round |> Duration.from_nanoseconds |> combine_duration_res_and_time time
 
         ([_, _, _, _, _, _], Ok frac) -> # hhmmss
-            time = parseLocalTimeBasic? wholeBytes
-            frac * Const.nanosPerSecond |> Num.round |> Duration.fromNanoseconds |> combineDurationResAndTime time
+            time = parse_local_time_basic? whole_bytes
+            frac * Const.nanos_per_second |> Num.round |> Duration.from_nanoseconds |> combine_duration_res_and_time time
 
         ([_, _, ':', _, _, ':', _, _], Ok frac) -> # hh:mm:ss
-            time = parseLocalTimeExtended? wholeBytes
-            frac * Const.nanosPerSecond |> Num.round |> Duration.fromNanoseconds |> combineDurationResAndTime time
+            time = parse_local_time_extended? whole_bytes
+            frac * Const.nanos_per_second |> Num.round |> Duration.from_nanoseconds |> combine_duration_res_and_time time
 
         _ -> Err InvalidTimeFormat
 
-parseTimeOffset : List U8 -> Result Duration [InvalidTimeFormat]
-parseTimeOffset = \bytes ->
+parse_time_offset : List U8 -> Result Duration [InvalidTimeFormat]
+parse_time_offset = \bytes ->
     when bytes is
         ['-', h1, h2] ->
-            parseTimeOffsetHelp h1 h2 '0' '0' 1
+            parse_time_offset_help h1 h2 '0' '0' 1
 
         ['+', h1, h2] ->
-            parseTimeOffsetHelp h1 h2 '0' '0' -1
+            parse_time_offset_help h1 h2 '0' '0' -1
 
         ['-', h1, h2, m1, m2] ->
-            parseTimeOffsetHelp h1 h2 m1 m2 1
+            parse_time_offset_help h1 h2 m1 m2 1
 
         ['+', h1, h2, m1, m2] ->
-            parseTimeOffsetHelp h1 h2 m1 m2 -1
+            parse_time_offset_help h1 h2 m1 m2 -1
 
         ['-', h1, h2, ':', m1, m2] ->
-            parseTimeOffsetHelp h1 h2 m1 m2 1
+            parse_time_offset_help h1 h2 m1 m2 1
 
         ['+', h1, h2, ':', m1, m2] ->
-            parseTimeOffsetHelp h1 h2 m1 m2 -1
+            parse_time_offset_help h1 h2 m1 m2 -1
 
         _ -> Err InvalidTimeFormat
 
-parseTimeOffsetHelp : U8, U8, U8, U8, I64 -> Result Duration [InvalidTimeFormat]
-parseTimeOffsetHelp = \h1, h2, m1, m2, sign ->
-    isValidOffset = \offset -> if offset >= -14 * Const.nanosPerHour && offset <= 12 * Const.nanosPerHour then Valid else Invalid
-    when (utf8ToIntSigned [h1, h2], utf8ToIntSigned [m1, m2]) is
+parse_time_offset_help : U8, U8, U8, U8, I64 -> Result Duration [InvalidTimeFormat]
+parse_time_offset_help = \h1, h2, m1, m2, sign ->
+    is_valid_offset = \offset -> if offset >= -14 * Const.nanos_per_hour && offset <= 12 * Const.nanos_per_hour then Valid else Invalid
+    when (utf8_to_int_signed [h1, h2], utf8_to_int_signed [m1, m2]) is
         (Ok hour, Ok minute) ->
-            offsetNanos = sign * (hour * Const.nanosPerHour + minute * Const.nanosPerMinute)
-            when isValidOffset offsetNanos is
-                Valid -> Duration.fromNanoseconds offsetNanos |> Result.mapErr \_ -> InvalidTimeFormat
+            offset_nanos = sign * (hour * Const.nanos_per_hour + minute * Const.nanos_per_minute)
+            when is_valid_offset offset_nanos is
+                Valid -> Duration.from_nanoseconds offset_nanos |> Result.mapErr \_ -> InvalidTimeFormat
                 Invalid -> Err InvalidTimeFormat
 
         (_, _) -> Err InvalidTimeFormat
 
-parseLocalTimeHour : List U8 -> Result Time [InvalidTimeFormat]
-parseLocalTimeHour = \bytes ->
-    when utf8ToIntSigned bytes is
+parse_local_time_hour : List U8 -> Result Time [InvalidTimeFormat]
+parse_local_time_hour = \bytes ->
+    when utf8_to_int_signed bytes is
         Ok hour if hour >= 0 && hour <= 24 ->
-            Time.fromHms hour 0 0 |> Ok
+            Time.from_hms hour 0 0 |> Ok
 
         Ok _ -> Err InvalidTimeFormat
         Err _ -> Err InvalidTimeFormat
 
-parseLocalTimeMinuteBasic : List U8 -> Result Time [InvalidTimeFormat]
-parseLocalTimeMinuteBasic = \bytes ->
-    when splitListAtIndices bytes [2] is
-        [hourBytes, minuteBytes] ->
-            when (utf8ToIntSigned hourBytes, utf8ToIntSigned minuteBytes) is
+parse_local_time_minute_basic : List U8 -> Result Time [InvalidTimeFormat]
+parse_local_time_minute_basic = \bytes ->
+    when split_list_at_indices bytes [2] is
+        [hour_bytes, minute_bytes] ->
+            when (utf8_to_int_signed hour_bytes, utf8_to_int_signed minute_bytes) is
                 (Ok hour, Ok minute) if hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 ->
-                    Time.fromHms hour minute 0 |> Ok
+                    Time.from_hms hour minute 0 |> Ok
 
                 (Ok 24, Ok 0) ->
-                    Time.fromHms 24 0 0 |> Ok
+                    Time.from_hms 24 0 0 |> Ok
 
                 (_, _) -> Err InvalidTimeFormat
 
         _ -> Err InvalidTimeFormat
 
-parseLocalTimeMinuteExtended : List U8 -> Result Time [InvalidTimeFormat]
-parseLocalTimeMinuteExtended = \bytes ->
-    when splitListAtIndices bytes [2, 3] is
-        [hourBytes, _, minuteBytes] ->
-            when (utf8ToIntSigned hourBytes, utf8ToIntSigned minuteBytes) is
+parse_local_time_minute_extended : List U8 -> Result Time [InvalidTimeFormat]
+parse_local_time_minute_extended = \bytes ->
+    when split_list_at_indices bytes [2, 3] is
+        [hour_bytes, _, minute_bytes] ->
+            when (utf8_to_int_signed hour_bytes, utf8_to_int_signed minute_bytes) is
                 (Ok hour, Ok minute) if hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 ->
-                    Time.fromHms hour minute 0 |> Ok
+                    Time.from_hms hour minute 0 |> Ok
 
                 (Ok 24, Ok 0) ->
-                    Time.fromHms 24 0 0 |> Ok
+                    Time.from_hms 24 0 0 |> Ok
 
                 (_, _) -> Err InvalidTimeFormat
 
         _ -> Err InvalidTimeFormat
 
-parseLocalTimeBasic : List U8 -> Result Time [InvalidTimeFormat]
-parseLocalTimeBasic = \bytes ->
-    when splitListAtIndices bytes [2, 4] is
-        [hourBytes, minuteBytes, secondBytes] ->
-            when (utf8ToIntSigned hourBytes, utf8ToIntSigned minuteBytes, utf8ToIntSigned secondBytes) is
+parse_local_time_basic : List U8 -> Result Time [InvalidTimeFormat]
+parse_local_time_basic = \bytes ->
+    when split_list_at_indices bytes [2, 4] is
+        [hour_bytes, minute_bytes, second_bytes] ->
+            when (utf8_to_int_signed hour_bytes, utf8_to_int_signed minute_bytes, utf8_to_int_signed second_bytes) is
                 (Ok h, Ok m, Ok s) if h >= 0 && h <= 23 && m >= 0 && m <= 59 && s >= 0 && s <= 59 ->
-                    Time.fromHms h m s |> Ok
+                    Time.from_hms h m s |> Ok
 
                 (Ok 24, Ok 0, Ok 0) ->
-                    Time.fromHms 24 0 0 |> Ok
+                    Time.from_hms 24 0 0 |> Ok
 
                 (_, _, _) -> Err InvalidTimeFormat
 
         _ -> Err InvalidTimeFormat
 
-parseLocalTimeExtended : List U8 -> Result Time [InvalidTimeFormat]
-parseLocalTimeExtended = \bytes ->
-    when splitListAtIndices bytes [2, 3, 5, 6] is
-        [hourBytes, _, minuteBytes, _, secondBytes] ->
-            when (utf8ToIntSigned hourBytes, utf8ToIntSigned minuteBytes, utf8ToIntSigned secondBytes) is
+parse_local_time_extended : List U8 -> Result Time [InvalidTimeFormat]
+parse_local_time_extended = \bytes ->
+    when split_list_at_indices bytes [2, 3, 5, 6] is
+        [hour_bytes, _, minute_bytes, _, second_bytes] ->
+            when (utf8_to_int_signed hour_bytes, utf8_to_int_signed minute_bytes, utf8_to_int_signed second_bytes) is
                 (Ok h, Ok m, Ok s) if h >= 0 && h <= 23 && m >= 0 && m <= 59 && s >= 0 && s <= 59 ->
-                    Time.fromHms h m s |> Ok
+                    Time.from_hms h m s |> Ok
 
                 (Ok 24, Ok 0, Ok 0) ->
-                    Time.fromHms 24 0 0 |> Ok
+                    Time.from_hms 24 0 0 |> Ok
 
                 (_, _, _) -> Err InvalidTimeFormat
 
@@ -342,47 +342,47 @@ parseLocalTimeExtended = \bytes ->
 
 # <===== TESTS ====>
 # <---- addNanoseconds ---->
-expect addNanoseconds (fromHmsn 12 34 56 5) Const.nanosPerSecond == fromHmsn 12 34 57 5
-expect addNanoseconds (fromHmsn 12 34 56 5) -Const.nanosPerSecond == fromHmsn 12 34 55 5
+expect add_nanoseconds (from_hmsn 12 34 56 5) Const.nanos_per_second == from_hmsn 12 34 57 5
+expect add_nanoseconds (from_hmsn 12 34 56 5) -Const.nanos_per_second == from_hmsn 12 34 55 5
 
 # <---- addSeconds ---->
-expect addSeconds (fromHms 12 34 56) 59 == fromHms 12 35 55
-expect addSeconds (fromHms 12 34 56) -59 == fromHms 12 33 57
+expect add_seconds (from_hms 12 34 56) 59 == from_hms 12 35 55
+expect add_seconds (from_hms 12 34 56) -59 == from_hms 12 33 57
 
 # <---- addMinutes ---->
-expect addMinutes (fromHms 12 34 56) 59 == fromHms 13 33 56
-expect addMinutes (fromHms 12 34 56) -59 == fromHms 11 35 56
+expect add_minutes (from_hms 12 34 56) 59 == from_hms 13 33 56
+expect add_minutes (from_hms 12 34 56) -59 == from_hms 11 35 56
 
 # <---- addHours ---->
-expect addHours (fromHms 12 34 56) 1 == fromHms 13 34 56
-expect addHours (fromHms 12 34 56) -1 == fromHms 11 34 56
-expect addHours (fromHms 12 34 56) 12 == fromHms 24 34 56
+expect add_hours (from_hms 12 34 56) 1 == from_hms 13 34 56
+expect add_hours (from_hms 12 34 56) -1 == from_hms 11 34 56
+expect add_hours (from_hms 12 34 56) 12 == from_hms 24 34 56
 
 # <---- addTimeAndDuration ---->
 expect
-    addTimeAndDuration (fromHms 0 0 0) (Duration.fromHours 1 |> unwrap "will not overflow") == fromHms 1 0 0
+    add_time_and_duration (from_hms 0 0 0) (Duration.from_hours 1 |> unwrap "will not overflow") == from_hms 1 0 0
 
 # <---- fromNanosSinceMidnight ---->
-expect fromNanosSinceMidnight -123 == fromHmsn -1 59 59 999_999_877
-expect fromNanosSinceMidnight 0 == midnight
-expect fromNanosSinceMidnight (24 * Const.nanosPerHour) == fromHms 24 0 0
-expect fromNanosSinceMidnight (25 * nanosPerHour) == fromHms 25 0 0
-expect fromNanosSinceMidnight (12 * nanosPerHour + 34 * nanosPerMinute + 56 * nanosPerSecond + 5) == fromHmsn 12 34 56 5
+expect from_nanos_since_midnight -123 == from_hmsn -1 59 59 999_999_877
+expect from_nanos_since_midnight 0 == midnight
+expect from_nanos_since_midnight (24 * Const.nanos_per_hour) == from_hms 24 0 0
+expect from_nanos_since_midnight (25 * nanos_per_hour) == from_hms 25 0 0
+expect from_nanos_since_midnight (12 * nanos_per_hour + 34 * nanos_per_minute + 56 * nanos_per_second + 5) == from_hmsn 12 34 56 5
 
 # <---- toIsoStr ---->
-expect toIsoStr (fromHmsn 12 34 56 5) == "12:34:56,000000005"
-expect toIsoStr midnight == "00:00:00"
+expect to_iso_str (from_hmsn 12 34 56 5) == "12:34:56,000000005"
+expect to_iso_str midnight == "00:00:00"
 expect
-    str = toIsoStr (fromHmsn 0 0 0 500_000_000)
+    str = to_iso_str (from_hmsn 0 0 0 500_000_000)
     str == "00:00:00,5"
 
 # <---- fromNanosSinceMidnight ---->
-expect fromNanosSinceMidnight -123 == fromHmsn -1 59 59 999_999_877
-expect fromNanosSinceMidnight 0 == midnight
-expect fromNanosSinceMidnight (24 * Const.nanosPerHour) == fromHms 24 0 0
-expect fromNanosSinceMidnight (25 * Const.nanosPerHour) == fromHms 25 0 0
+expect from_nanos_since_midnight -123 == from_hmsn -1 59 59 999_999_877
+expect from_nanos_since_midnight 0 == midnight
+expect from_nanos_since_midnight (24 * Const.nanos_per_hour) == from_hms 24 0 0
+expect from_nanos_since_midnight (25 * Const.nanos_per_hour) == from_hms 25 0 0
 
 # <---- toNanosSinceMidnight ---->
-expect toNanosSinceMidnight { hour: 12, minute: 34, second: 56, nanosecond: 5 } == 12 * nanosPerHour + 34 * nanosPerMinute + 56 * nanosPerSecond + 5
-expect toNanosSinceMidnight (fromHmsn 12 34 56 5) == 12 * Const.nanosPerHour + 34 * Const.nanosPerMinute + 56 * Const.nanosPerSecond + 5
-expect toNanosSinceMidnight (fromHmsn -1 0 0 0) == -1 * Const.nanosPerHour
+expect to_nanos_since_midnight { hour: 12, minute: 34, second: 56, nanosecond: 5 } == 12 * nanos_per_hour + 34 * nanos_per_minute + 56 * nanos_per_second + 5
+expect to_nanos_since_midnight (from_hmsn 12 34 56 5) == 12 * Const.nanos_per_hour + 34 * Const.nanos_per_minute + 56 * Const.nanos_per_second + 5
+expect to_nanos_since_midnight (from_hmsn -1 0 0 0) == -1 * Const.nanos_per_hour


### PR DESCRIPTION
This migrates the package identifiers to snake case. This does not include roc builtins, which will be updated when that change ships.