### PR TITLE
Added sub functions and Durations now saturate 

### DIFF
--- a/package/Duration.roc
+++ b/package/Duration.roc
@@ -15,7 +15,6 @@ module [
 ]
 
 import Const
-import rtils.Unsafe exposing [unwrap] # for unit testing only
 
 ## ```
 ## Duration : {
@@ -29,164 +28,154 @@ import rtils.Unsafe exposing [unwrap] # for unit testing only
 Duration : { days : I64, hours : I8, minutes : I8, seconds : I8, nanoseconds : I32 }
 
 ## Create a `Duration` object from nanoseconds.
-from_nanoseconds : Int * -> Result Duration [DurationOverflow]
-from_nanoseconds = |nanos|
-    if
-        (nanos // Const.nanos_per_day |> Num.to_i128) > (Num.max_i64 |> Num.to_i128)
-    then
-        Err(DurationOverflow)
-    else
-        Ok(
-            {
-                days: nanos // (Const.nanos_per_day) |> Num.to_i64,
-                hours: (nanos % (Const.nanos_per_day)) // Const.nanos_per_hour |> Num.to_i8,
-                minutes: (nanos % Const.nanos_per_hour) // Const.nanos_per_minute |> Num.to_i8,
-                seconds: (nanos % Const.nanos_per_minute) // Const.nanos_per_second |> Num.to_i8,
-                nanoseconds: nanos % Const.nanos_per_second |> Num.to_i32,
-            },
-        )
+from_nanoseconds : Int * -> Duration
+from_nanoseconds = |nanos| 
+    nanos_saturated =
+        if (Num.to_i128(nanos) // Const.nanos_per_day) > (Num.max_i64 |> Num.to_i128) then
+            (Num.max_i64 |> Num.to_i128) * Const.nanos_per_day
+        else if (Num.to_i128(nanos) // Const.nanos_per_day) < (Num.min_i64 |> Num.to_i128) then
+            (Num.min_i64 |> Num.to_i128) * Const.nanos_per_day
+        else
+            nanos |> Num.to_i128
+    {
+        days: nanos_saturated // (Const.nanos_per_day) |> Num.to_i64,
+        hours: (nanos_saturated % (Const.nanos_per_day)) // Const.nanos_per_hour |> Num.to_i8,
+        minutes: (nanos_saturated % Const.nanos_per_hour) // Const.nanos_per_minute |> Num.to_i8,
+        seconds: (nanos_saturated % Const.nanos_per_minute) // Const.nanos_per_second |> Num.to_i8,
+        nanoseconds: nanos_saturated % Const.nanos_per_second |> Num.to_i32,
+    }
 
 ## Convert a `Duration` object to nanoseconds.
 to_nanoseconds : Duration -> I128
 to_nanoseconds = |duration|
     (Num.to_i128(duration.nanoseconds))
-    + (Num.to_i128(duration.seconds))
-    * Const.nanos_per_second
-    + (Num.to_i128(duration.minutes))
-    * Const.nanos_per_minute
-    + (Num.to_i128(duration.hours))
-    * Const.nanos_per_hour
-    + (Num.to_i128(duration.days))
-    * (Const.nanos_per_hour * 24)
+    |> Num.add_saturated((Num.to_i128(duration.seconds)) |> Num.mul_saturated(Const.nanos_per_second))
+    |> Num.add_saturated((Num.to_i128(duration.minutes)) |> Num.mul_saturated(Const.nanos_per_minute))
+    |> Num.add_saturated((Num.to_i128(duration.hours)) |> Num.mul_saturated(Const.nanos_per_hour))
+    |> Num.add_saturated((Num.to_i128(duration.days)) |> Num.mul_saturated(Const.nanos_per_day))
 
 ## Create a `Duration` object from seconds.
-from_seconds : Int * -> Result Duration [DurationOverflow]
-from_seconds = |seconds|
-    if
-        (seconds // Const.seconds_per_day |> Num.to_i128) > (Num.max_i64 |> Num.to_i128)
-    then
-        Err(DurationOverflow)
-    else
-        Ok(
-            {
-                days: seconds // (Const.seconds_per_day) |> Num.to_i64,
-                hours: (seconds % (Const.seconds_per_day)) // Const.seconds_per_hour |> Num.to_i8,
-                minutes: (seconds % Const.seconds_per_hour) // Const.seconds_per_minute |> Num.to_i8,
-                seconds: seconds % Const.seconds_per_minute |> Num.to_i8,
-                nanoseconds: 0,
-            },
-        )
+from_seconds : Int * -> Duration
+from_seconds = |seconds| 
+    seconds_saturated = 
+        if (Num.to_i128(seconds) // (Const.seconds_per_day)) > (Num.max_i64 |> Num.to_i128) then
+            (Num.max_i64 |> Num.to_i128) * (Const.seconds_per_day)
+        else if (Num.to_i128(seconds) // (Const.seconds_per_day)) < (Num.min_i64 |> Num.to_i128) then
+            (Num.min_i64 |> Num.to_i128) * (Const.seconds_per_day)
+        else
+            seconds |> Num.to_i128
+    {
+        days: seconds_saturated // (Const.seconds_per_day) |> Num.to_i64,
+        hours: (seconds_saturated % (Const.seconds_per_day)) // Const.seconds_per_hour |> Num.to_i8,
+        minutes: (seconds_saturated % Const.seconds_per_hour) // Const.seconds_per_minute |> Num.to_i8,
+        seconds: seconds_saturated % Const.seconds_per_minute |> Num.to_i8,
+        nanoseconds: 0,
+    }
 
 ## Convert a `Duration` object to seconds (truncates nanoseconds).
-to_seconds : Duration -> I128
+to_seconds : Duration -> I64
 to_seconds = |duration|
-    (Num.to_i128(duration.seconds))
-    + (Num.to_i128(duration.minutes))
-    * Const.seconds_per_minute
-    + (Num.to_i128(duration.hours))
-    * Const.seconds_per_hour
-    + (Num.to_i128(duration.days))
-    * (Const.seconds_per_hour * 24)
+    (Num.to_i64(duration.seconds)) 
+    |> Num.add_saturated((Num.to_i64(duration.minutes)) |> Num.mul_saturated(Const.seconds_per_minute))
+    |> Num.add_saturated((Num.to_i64(duration.hours)) |> Num.mul_saturated(Const.seconds_per_hour))
+    |> Num.add_saturated((duration.days) |> Num.mul_saturated(Const.seconds_per_day))
 
 ## Create a `Duration` object from minutes.
-from_minutes : Int * -> Result Duration [DurationOverflow]
-from_minutes = |minutes|
-    if
-        (minutes // Const.minutes_per_day |> Num.to_i128) > (Num.max_i64 |> Num.to_i128)
-    then
-        Err(DurationOverflow)
-    else
-        Ok(
-            {
-                days: minutes // (Const.minutes_per_day) |> Num.to_i64,
-                hours: (minutes % (Const.minutes_per_day)) // Const.minutes_per_hour |> Num.to_i8,
-                minutes: minutes % Const.minutes_per_hour |> Num.to_i8,
-                seconds: 0,
-                nanoseconds: 0,
-            },
-        )
+from_minutes : Int * -> Duration
+from_minutes = |minutes| 
+    minutes_saturated = 
+        if (Num.to_i128(minutes) // (Const.minutes_per_day)) > (Num.max_i64 |> Num.to_i128) then
+            (Num.max_i64 |> Num.to_i128) * (Const.minutes_per_day)
+        else if (Num.to_i128(minutes) // (Const.minutes_per_day)) < (Num.min_i64 |> Num.to_i128) then
+            (Num.min_i64 |> Num.to_i128) * (Const.minutes_per_day)
+        else
+            minutes |> Num.to_i128
+    {
+        days: minutes_saturated // (Const.minutes_per_day) |> Num.to_i64,
+        hours: (minutes_saturated % (Const.minutes_per_day)) // Const.minutes_per_hour |> Num.to_i8,
+        minutes: minutes_saturated % Const.minutes_per_hour |> Num.to_i8,
+        seconds: 0,
+        nanoseconds: 0,
+    }
 
 ## Convert a `Duration` object to minutes (truncates seconds and lower).
-to_minutes : Duration -> I128
+to_minutes : Duration -> I64
 to_minutes = |duration|
-    (Num.to_i128(duration.minutes))
-    + (Num.to_i128(duration.hours))
-    * Const.minutes_per_hour
-    + (Num.to_i128(duration.days))
-    * (Const.minutes_per_hour * 24)
+    (Num.to_i64(duration.minutes))
+    |> Num.add_saturated((Num.to_i64(duration.hours)) |> Num.mul_saturated(Const.minutes_per_hour))
+    |> Num.add_saturated((duration.days) |> Num.mul_saturated(Const.minutes_per_day))
 
 ## Create a `Duration` object from hours.
-from_hours : Int * -> Result Duration [DurationOverflow]
+from_hours : Int * -> Duration
 from_hours = |hours|
-    if
-        (hours // 24 |> Num.to_i128) > (Num.max_i64 |> Num.to_i128)
-    then
-        Err(DurationOverflow)
-    else
-        Ok(
-            {
-                days: hours // 24 |> Num.to_i64,
-                hours: hours % 24 |> Num.to_i8,
-                minutes: 0,
-                seconds: 0,
-                nanoseconds: 0,
-            },
-        )
+    hours_saturated = 
+        if (Num.to_i128(hours) // (24)) > (Num.max_i64 |> Num.to_i128) then
+            (Num.max_i64 |> Num.to_i128) * (24)
+        else if (Num.to_i128(hours) // (24)) < (Num.min_i64 |> Num.to_i128) then
+            (Num.min_i64 |> Num.to_i128) * (24)
+        else
+            hours |> Num.to_i128
+    {
+        days: hours_saturated // 24 |> Num.to_i64,
+        hours: hours_saturated % 24 |> Num.to_i8,
+        minutes: 0,
+        seconds: 0,
+        nanoseconds: 0,
+    }
 
 ## Convert a `Duration` object to hours (truncates minutes and lower).
-to_hours : Duration -> I128
+to_hours : Duration -> I64
 to_hours = |duration|
-    (Num.to_i128(duration.hours))
-    + (Num.to_i128(duration.days))
-    * 24
+    (Num.to_i64(duration.hours))
+    |> Num.add_saturated((Num.to_i64(duration.days)) |> Num.mul_saturated(24))
 
 ## Create a `Duration` object from days.
-from_days : Int * -> Result Duration [DurationOverflow]
-from_days = |days|
-    if
-        days |> Num.to_i128 > Num.max_i64 |> Num.to_i128
-    then
-        Err(DurationOverflow)
-    else
-        Ok(
-            {
-                days: days |> Num.to_i64,
-                hours: 0,
-                minutes: 0,
-                seconds: 0,
-                nanoseconds: 0,
-            },
-        )
+from_days : Int * -> Duration
+from_days = |days| 
+    days_saturated = 
+        if (Num.to_i128(days)) > (Num.max_i64 |> Num.to_i128) then
+            Num.max_i64 |> Num.to_i128
+        else if (Num.to_i128(days)) < (Num.min_i64 |> Num.to_i128) then
+            Num.min_i64 |> Num.to_i128
+        else
+            days |> Num.to_i128
+    {
+        days: days_saturated |> Num.to_i64,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+        nanoseconds: 0,
+    }
 
 ## Convert a `Duration` object to days (truncates hours and lower).
 to_days : Duration -> I64
 to_days = |duration| duration.days
 
 ## Add two `Duration` objects.
-add_durations : Duration, Duration -> Result Duration [DurationOverflow]
+add_durations : Duration, Duration -> Duration
 add_durations = |d1, d2|
     nanos1 = to_nanoseconds(d1)
     nanos2 = to_nanoseconds(d2)
-    from_nanoseconds((nanos1 + nanos2))
+    nanos1 |> Num.add_saturated(nanos2) |> from_nanoseconds
 
 expect
     days = Num.max_i64
-    duration = from_days(days) |> unwrap("will not overflow")
+    duration = from_days(days)
     duration |> to_days == days
 
 expect
-    d1 = from_days(Num.max_i64 // 2) |> unwrap("will not overflow")
-    d2 = from_days(Num.max_i64 // 2) |> unwrap("will not overflow")
-    d3 = from_days((Num.max_i64 // 2) * 2) |> unwrap("will not overflow")
-    add_durations(d1, d2) == Ok(d3)
+    d1 = from_days(Num.max_i64 // 2)
+    d2 = from_days(Num.max_i64 // 2)
+    d3 = from_days((Num.max_i64 // 2) * 2)
+    add_durations(d1, d2) == d3
 
 expect
-    d1 = from_days(Num.min_i64) |> unwrap("will not overflow")
-    d2 = from_days(Num.max_i64) |> unwrap("will not overflow")
-    d3 = from_days(-1) |> unwrap("will not overflow")
-    add_durations(d1, d2) == Ok(d3)
+    d1 = from_days(Num.min_i64)
+    d2 = from_days(Num.max_i64)
+    add_durations(d1, d2) == from_days(-1)
 
 expect
-    duration = from_days(Num.max_i64) |> unwrap("will not overflow")
-    add_durations(duration, duration) == Err(DurationOverflow)
+    days = Num.max_i64
+    duration = from_days(days)
+    add_durations(duration, duration) == from_days(days)
 


### PR DESCRIPTION
`Duration`s now saturate in constructors and math functions instead of returning a `Result Duration [DurationOverflow]`